### PR TITLE
Fixed ragged right-hand margins

### DIFF
--- a/whitepaper/preface.tex
+++ b/whitepaper/preface.tex
@@ -46,7 +46,8 @@ The main points we aim to convey in this white paper are as follows:
 
 \end{itemize}
 
-\raggedright{Project start: July 2015.}
+%\raggedright{Project start: July 2015.}
+Project start: July 2015.
 
 \clearpage
 


### PR DESCRIPTION
A \raggedright{ } in the Preface caused ragged right-hand margins throughout the rest of the document.