### PR TITLE
4.4 - Minor typo fix

### DIFF
--- a/whitepaper/MilkyWay/MW_Astrometry.tex
+++ b/whitepaper/MilkyWay/MW_Astrometry.tex
@@ -22,8 +22,7 @@ science cases at opposite scales of distance from the Sun that require
 accurate and precise astrometry and/or proper motion
 measurements. Section \ref{sec:keyword:MW_Astrometry_metrics} develops
 Metrics for LSST's astrometric performance, and discusses Figures of
-Merit for the two science cases that would depend on these
-Metrics. These metrics are applied to two example OpSim runs in
+Merit for the two highlighted science cases. These metrics are applied to two example OpSim runs in
 Section \ref{sec:keyword:MW_Astrometry_OpSim}. Finally in Section
 \ref{sec:keyword:MW_Astrometry_furtherwork}, the work that is still
 needed is discussed, both in terms of the Metrics and the Figures of


### PR DESCRIPTION
"the two science cases" --> "two highlighted science cases"