### PR TITLE
Added summary tables for Figures of Merit; minor typo fixes

### DIFF
--- a/whitepaper/MilkyWay/MW_Astrometry.tex
+++ b/whitepaper/MilkyWay/MW_Astrometry.tex
@@ -216,8 +216,6 @@ location on-sky, subdivided by elapsed time in the survey (Figures \ref{fig_astr
 \item[I3.] For the extremes of object color (objects detected only in the bluest or only in the reddest filter), the differences between strategies is weaker. The run \opsimdbref{db:enigma} still shows a population with poorer parallax measures (although this might be due to coverage of regions simply not covered at all by the PanSTARRS-like strategy).
 \end{itemize}
 
-({\it Summary table would help...})
-
 %% In the current incarnation, these will be LARGE figures. Consider
 %% finding a way to summarize them!
 \begin{figure}[ht]
@@ -434,7 +432,9 @@ location on-sky, subdivided by elapsed time in the survey (Figures \ref{fig_astr
 
 \subsubsection{Figures of Merit depening on the Metrics}
 
-Building on the first-order metrics above, this piece will communicate scientific figures of merit for the cases identified in Section \ref{sec:\secname:MW_Astrometry_measurements} above.
+Building on the first-order metrics above, this subsection will communicate scientific figures of merit for the cases identified in Section \ref{sec:\secname:MW_Astrometry_measurements} above.
+
+\new{Table \ref{tab_SummaryMWAstrometry} summarizes the Figures of Merit for Astrometry science cases.}
 
 \subsection{Topics that will need to be addressed}
 \label{sec:\secname:MW_Astrometry_furtherwork}
@@ -466,6 +466,31 @@ figures of merit might then be:
   \item[3.] Uncertainty and bias in the Brown Dwarf mass function using Solar Neighborhood tracers;
    \item[4.] Uncertainty and bias in the thickness in the main sequence of M-dwarfs within 25pc from the Sun, once variability has been characterized and removed.
 \end{itemize}
+
+%%%% SUMMARY TABLE FOR THIS SECTION
+
+\begin{table}
+  \begin{tabular}{l|p{6cm}|c|c|c|c|p{5cm}}
+    FoM & Brief description & {\rotatebox{90}{enigma-1189}} & {\rotatebox{90}{ops2-1092}} & {\rotatebox{90}{future run 1}} &  {\rotatebox{90}{future run 2}} & Notes \\
+    \hline
+    1.1 & \footnotesize{Median parallax error at $g=21$ (main survey)}      & - & - & - & - & \footnotesize{Summarize the presentation in Figures \ref{fig_astrom_ByTime_PACoverage}-\ref{fig_astrom_ByFilter_paError}} \\
+    1.2. & \footnotesize{Median parallax error at $g=21$ (plane)}   & - & - & - & - &  - \\
+    1.3. & \footnotesize{Median proper motion error at $g=21$ (main survey)}  & - & - & - & - &  \footnotesize{Take median of Figure \ref{fig_astrom_ByTime_pmError} over the ``plane'' region} \\
+    1.4. & \footnotesize{Median proper motion error at $g=21$ (plane)} & - & - & - & - &  - \\
+    \hline
+    2.1. & \footnotesize{Number of streams LSST can discover via proper motions} & - & - & - & - &  - \\
+    3.1. & \footnotesize{Uncertainty and bias in thin- and thick-disk differential age measurement via white dwarfs} & - & - & - & - &  - \\
+    4.1. & \footnotesize{Uncertainty and bias in brown dwarf mass function from the Solar Neighborhood}  & - & - & - & - & \footnotesize{Using astrometry metrics for objects detected only in the reddest filter(s)} \\
+    4.2. & \footnotesize{Uncertainty and bias in white dwarf mass function from the Solar Neighborhood}  & - & - & - & - & \footnotesize{Using astrometry metrics for objects detected only in the bluest filter(s)} \\
+    5.1. & \footnotesize{Uncertainty and bias in Solar Neighborhood M-dwarf thickness on the MS}  & - & - & - & - &  - \\
+\end{tabular}
+\caption{Summary of figures-of-merit for the Milky Way Astrometry science cases. The best value of each FoM is indicated in bold. See Section \ref{sec:MW_Astrometry}. \new{At present (Feb 2016) these FoMs are all placeholders. Expert input is welcome!}}
+\label{tab_SummaryMWAstrometry}
+\end{table}
+
+
+%%%% SUMMARY TABLE FINISHES HERE
+
 
 \subsubsection{Further work on Astrometry Metrics}
 

--- a/whitepaper/MilkyWay/MW_Disk.tex
+++ b/whitepaper/MilkyWay/MW_Disk.tex
@@ -411,7 +411,7 @@ Dependencies:
 \begin{itemize}
 \item \new{{\it Definition:} 
 \begin{equation}
-  FoM_{preSN} \equiv \frac{ \sum^{sightlines}_{i} f_{var, i} N_{\ast, i} } {\sum^{sightlines}_{i} N_{ast, i}}
+  FoM_{preSN} \equiv \frac{ \sum^{sightlines}_{i} f_{var, i} N_{\ast, i} } {\sum^{sightlines}_{i} N_{\ast, i}}
 \end{equation}
 where $f_{var, i}$~is the fraction of transient events that LSST would detect for observing strategy including the $i$'th sightline, $N_{\ast,i}$~the number of stars present along the $i$'th sightline, and the FoM is normalized by the total number of stars returned by the density model over all sightlines. (For the two OpSim runs tested here, enigma-1189 and ops2-1092, the normalization factors differ by $\sim 0.1\%$.) Therefore $0.0 \le FoM_{preSN} \le 1.0$.}
 \item \new{{\it Assumptions (observational):} Pre-SN variability similar to the
@@ -488,7 +488,7 @@ deep-wide-fast survey:
     5.1a & \footnotesize{Median (over sight-lines) of the uncertainty in $E(B-V)$} & - & - & - & - & \footnotesize{(Most useful FoM probably a spatial map of the uncertainty.)} \\
     5.1b & \footnotesize{Variance (over sight-lines) of the uncertainty in $E(B-V)$} & - & - & - & - & - \\
   \end{tabular}
-\caption{Summary of figures-of-merit for the Galactic Disk science cases. The best value of each FoM is indicated in bold.}
+\caption{Summary of figures-of-merit for the Galactic Disk science cases. The best value of each FoM is indicated in bold. See Section \ref{sec:MW_Disk}.}
 \label{tab_SummaryMWDisk}
 \end{table}
 

--- a/whitepaper/MilkyWay/MW_Halo.tex
+++ b/whitepaper/MilkyWay/MW_Halo.tex
@@ -142,6 +142,12 @@ galaxy sizes.
 \subsection{OpSim Analysis}
 \label{sec:\secname:MW_Halo_analysis}
 
+\new{Table \ref{tab_SummaryMWHalo} summarizes the science Figures of Merit
+for the Milky Way Halo science cases for LSST. OpSim analysis for this
+Section will be summarized in that Table; at the present date (Feb
+2016) placeholder rows are given for the FoM's. Input from the reader
+is welcome!}
+
 \begin{itemize}
 
 \item Comment on the north ecliptic spur in enigma\_1189. Is it close to the
@@ -149,8 +155,24 @@ WFD S/G limit?
 
 \item Pan-STARRS-like cadence ops2\_1092, observing up to dec +15. How much
 volume do we gain, and how much do we lose in the WFD survey?
-
 \end{itemize}
+
+%%% SUMMARY TABLE FOR THIS SUBSECTION
+
+\begin{table}
+  \begin{tabular}{l|p{6cm}|c|c|c|c|p{5cm}}
+    FoM & Brief description & {\rotatebox{90}{enigma-1189}} & {\rotatebox{90}{ops2-1092}} & {\rotatebox{90}{future run 1}} &  {\rotatebox{90}{future run 2}} & Notes \\
+    \hline
+    1.1. & \footnotesize{Survey volume to RR Lyraes}      & - & - & - & - & \footnotesize{Volume within which the distance to a template RR Lyrae star can be estimated to 10\% uncertainty.} \\
+    1.2. & \footnotesize{Survey volume to Main Sequence tracers down to limiting magnitude $X$} & - & - & - & - & \footnotesize{(Including star-galaxy separation for MS objects)} \\
+    1.3. & \footnotesize{Survey volume to Red Giants} & - & - & - & - & - \\
+    2.1. & \footnotesize{Completeness of metallicity sub-structure recovery as a function of distance} & - & - & - & - & \footnotesize{Over all three tracer populations?} \\ 
+    3.1. & \footnotesize{Uncertainty and bias in age distribution parameterization of the main Halo population} & - & - & - & - & - \\
+    3.2. & \footnotesize{Uncertainty and bias in the population fraction identified correctly with each halo component} & - & - & - & - & \footnotesize{Some overlap with Halo astrometry FoM?} \\
+\end{tabular}
+\caption{Summary of figures-of-merit (FoMs) for the Galactic Halo science cases. The best value of each FoM is indicated in bold. See Section \ref{sec:MW_Halo}. \new{At present (Feb 2016) these are placeholder FoMs. Expert input is welcome.}}
+\label{tab_SummaryMWHalo}
+\end{table}
 
 
 % --------------------------------------------------------------------

--- a/whitepaper/galaxy.tex
+++ b/whitepaper/galaxy.tex
@@ -38,7 +38,7 @@ make no attempt to be comprehensive. Much more detail about most of
 the LSST science cases, and specific science questions to be answered,
 can be found in the LSST Science Book (particularly chapters 6 and 7)
 and Ivezic et al. (2008 arXiv 0805.2366, in particular Sections 2.1.4
-and 4.4 of that document). In this chapter we present a few
+and 4.4 of that document).\footnote{\new{Since several of the science cases for populations in the Galactic Disk do not appear to have been developed elsewhere, however, Section \ref{sec:MW_Disk} does present motivating details for those science cases.}} In this chapter we present a few
 representative science cases that illustrate trade-offs between
 observing strategies, for programs at low galactic latitudes as well
 as away from the disk, and for programs requiring sufficient cadence
@@ -101,9 +101,21 @@ and constraints on radial migration in the mid-plane), while
 Section~\ref{sec:MW_LocalVolume} explores the use of LSST to probe the Local
 Volume.
 
+\subsection{Summary tables for Figures of Merit}
+
+\new{At-a-glance tables comparing Figures of Merit for the various science
+cases, will be found in the appropriate summary tables:}
+\begin{itemize}
+  \item Mapping the Milky Way Halo: Table \ref{tab_SummaryMWHalo}
+    \item Mapping the Milky Way Disk: Table \ref{tab_SummaryMWDisk}
+      \item Astrometry with LSST: Table \ref{tab_SummaryMWAstrometry}
+        \item The Milky Way Bulge: content needed
+          \item Mapping the Local Volume with Resolved Stars: content needed.   
+\end{itemize}
+
 \subsection{Needed input}
 
-Many of the diagnostic Metrics are (as of January 2016) relatively
+Many of the diagnostic Metrics are (as of February 2016) relatively
 well-developed. What is needed at this stage is the implementation of
 the figures of merit that depend on these Metrics. In some Sections we
 have sketched out such figures of merit, in others the development of


### PR DESCRIPTION
Sketched out summary tables for the Figures of Merit for Sections 4.2 (Halo) and 4.4 (Astrometry) in addition to 4.3 (Disk, was already present). A few other minor typo fixes.

Added subsection to preamble (galaxy.tex) with references to the summary tables within this chapter.

