### PR TITLE
Removed duplicate material; added Figure of Merit "pseudocode"

### DIFF
--- a/whitepaper/MilkyWay/MW_SFH.tex
+++ b/whitepaper/MilkyWay/MW_SFH.tex
@@ -27,6 +27,7 @@
 \def\secname{MW_SFH}\label{sec:\secname} % For example, replace "keyword" with "lenstimedelays"
 
 \noindent{\it Peregrine M. McGehee} % (Writing team)
+\label{sec:\secname:targets}
 
 % This individual section will need to describe the particular
 % discoveries and measurements that are being targeted in this section's
@@ -48,83 +49,67 @@ others, it would allow to study the Initial Mass Function down to the
 sub-stellar limit across different environments. Young stars are
 efficiently identified by their variability.
 
-LSST will increase the sample size for detailed follow-up observations due its ability to survey
-star formations at large heliocentric distances and to detect variability in embedded and highly
-extincted young objects that would otherwise be missed in shallower surveys. During its operations
-LSST will also provide statistics on the durations of high states, at least for the shorter duration
-EXor variables.
+\new{Section 8.10.2 in the LSST Science Book (p298--299) provides a
+  thorough scientific motivation for the characterization of young
+  stars through variability, including discussion of the observational
+  signatures of the diverse physical phenomena driving observed time
+  variability. The general observable is strong, irregular flaring
+  across the entire $ugrizy$~bandpass of LSST. Flaring can last from
+  minutes to years, and at amplitudes from a few tenths to several
+  magnitudes.}
+
+% WIC - the following para has been removed since it's already present
+% verbatim at the end of Section 8.10.2 in the LSST Science Book.
+
+%LSST will increase the sample size for detailed follow-up observations
+%due its ability to survey star formations at large heliocentric
+%distances and to detect variability in embedded and highly extincted
+%young objects that would otherwise be missed in shallower
+%surveys. During its operations LSST will also provide statistics on
+%the durations of high states, for at least one important tracer
+%population (the shorter-duration EXor variables).
 
 % --------------------------------------------------------------------
 
 \subsection{Target measurements and discoveries}
 \label{sec:\secname:targets}
 
-Variability is one of the distinguishing features of pre-main sequence stars and can result from a
-diverse collection of physical phenomena including rotational modulation of large starspots due to
-kiloGauss magnetic fields, hot spots formed by the impact of accretion streams onto the stellar
-photosphere, variations in the mass accretion rate, thermal emission from the circumstellar disk,
-and changes in the line of sight extinction. These physical processes generate irregular variability
-across the entire LSST wavelength range (320–1040 nm) with amplitudes of tenths to several
-magnitudes on timescales ranging from minutes to years and will be detectable by LSST.
+The nature of the variability in young stars changes with evolutionary
+status. For the youngest stars still undergoing significant mass
+accretion, FU Orionis and related outbursts can occur due to
+circumstellar disk instabilities. As the natal environment dissipates
+and the accretion rates drops, the stars take on a Classical T Tauri
+appearance where the variability is primarily due to changes in the
+accretion flow and rotational modulation of hot spots resulting from
+accretion shocks on the protostellar photosphere. Also present are the
+signature of cool spots arising from strong magnetic fields. This cool
+spot rotational modulation is responsible for the variability in the
+disk-less, and older, weak-line T Tauri stars.
 
-The natural of the variability in young stars changes with evolutionary status. For the youngest
-stars still undergoing significant mass accretion, FU Orionis and related outbursts can occur 
-due to circumstellar disk instabilities. As the natal environment dissipates and the accretion
-rates drops, the stars take on a Classical T Tauri appearance where the variability is 
-primarily due to changes in the accretion flow and rotational modulation of hot spots resulting
-from accretion shocks on the protostellar photosphere. Also present are the signature of
-cool spots arising from strong magnetic fields. This cool spot rotational modulation is 
-responsible for the variability in the disk-less, and older, Weak-line T Tauri stars.
+\new{Of particular interest are the FUor and EXor variables, which are
+  named after the prototype objects FU Orionis (Hartmann \& Kenyon
+  1996) and EX Lupi (Herbig et al. 2001) respectively, and for which
+  only a relatively small number of examples are known. In these
+  pre-main sequence objects, eruptive outbursts of up to 6 magnitudes
+  have been observed, with high state durations from years to
+  decades. In addition to triggering follow-up observations, LSST
+  should be able to set the first population constraints on the
+  duration of high states, particularly for the short end of the
+  timescale distribution for these eruptive variables.}
 
-{\bf CTTS and WTTS material goes here.}
 
-Due to its sensitivity and anticipated ten-year operations lifetime, LSST will also address the issue
-of the eruptive variability found in a rare class of young stellar objects - the FUor and EXor stars.
-FUor and EXor variables are named after the prototypes FU Orionis (Hartmann \& Kenyon 1996)
-and EX Lupi (Herbig et al. 2001) respectively. These stars exhibit outburst behavior characterized
-by an up to 6 magnitude increase in optical brightness, with high states persisting from several years
-to many decades. Both classes of objects are interpreted as pre-main sequence stars undergoing
-significantly increased mass accretion rate possibly due to instabilities in the circumstellar accretion
-disk. The mass accretion rates during eruption have been observed to increase by 3 to 4 orders
-of magnitude over the $\sim 10^{-9}$
-to $10^{-7} M_{\odot}$ per year typical of Classical T Tauri stars. Whether
-FUor/EXor eruptions are indeed the signature of an evolutionary phase in all young stars and
-whether these outbursts share common mechanisms and differ only in scale is still an open issue.
+\new{(WIC: Material already in LSST Science Book removed.)}
 
-To date only about 10 FUors, whose eruptions last for decades, having been observed to transition
-into outburst (Aspin et al. 2009) with the last major outburst being that of V1057 Cyg (Herbig
-1977). Repeat outbursts of several EXors have been studied, including those of EX Lupi (Herbig
-et al. 2001) and V1647 Ori (Aspin et al. 2009), the latter erupting in 1966, 2003, and 2008. The
-outbursts of EXors only persist for several months to roughly a year in contrast those of FUors,
-which may last for decades: for example, the prototype FU Ori has been in a high state for over
-70 years. These eruptions can occur very early in the evolution of a protostar as shown by the
-detection of EXor outbursts from a deeply embedded Class I protostar in the Serpens star formation
-region (Hodapp et al. 1996). The observed rarity of the FUor/EXor phenomenon may be due to
-the combination of both the relatively brief (less than 1 Myr) duration of the pre-T Tauri stage
-and the high line of sight extinction to these embedded objects hampering observation at optical
-and near-IR wavelengths.
 
-V1647 Ori is a well-studied EXor found in the Orion star formation region ($m−M = 8$) and
-thus is a suitable case study for discussion of LSST observations. 
-The
-inferred extinction is $A_r \sim 11$ magnitudes which coupled with the observed $r$ range of 23 to nearly
-17 during outburst (McGehee et al. 2004) suggest that $M_r$ varies from 4 to −2 magnitudes.
-The LSST single visit 5$\sigma$ depth for point sources is $r$ $\sim$ 24.7, thus analogs of V1647 Ori will
-be detectable in the $r$ band during quiescence to $(m−M) + A_r = 20.5$ and at maximum light
-to $(m − M) + A_r = 26.5$. The corresponding distance limits are 800 pc to 12 kpc assuming
-$A_r$ = 11. For objects at the distance of Orion the extinction limits for LSST $r$-band detections of
-a V1647 Ori analog are $A_r$ = 12.5 and $A_r$ = 17.5. These are conservative limits as V1647 Ori was
-several magnitudes brighter at longer wavelengths ($iz$ bands) during both outburst and quiescence
-indicating that the LSST observations in $izy$ will be even more sensitive to embedded FUor/EXor
-stars.
+%{\bf CTTS and WTTS material goes here.}
 
-Here are the references cited above:\\
-Hartmann \& Kenyon 1996, ARA\&A, 34, 207 \\
-Herbig et al. 2001, PASP, 113, 1547 \\
-Herbig 1977, ApJ, 217, 693 \\
-Aspin et al. 2009, ApJ, 692L, 67 \\
-Hodapp et al. 1996, ApJ, 468, 861 \\
-McGehee et al. 2004, ApJ, 616, 1058 \\
+%Here are the references cited above:\\
+%Hartmann \& Kenyon 1996, ARA\&A, 34, 207 \\
+%Herbig et al. 2001, PASP, 113, 1547 \\
+%Herbig 1977, ApJ, 217, 693 \\
+%Aspin et al. 2009, ApJ, 692L, 67 \\
+%Hodapp et al. 1996, ApJ, 468, 861 \\
+%McGehee et al. 2004, ApJ, 616, 1058 \\
 
 
 %Describe the discoveries and measurements you want to make.
@@ -141,27 +126,55 @@ McGehee et al. 2004, ApJ, 616, 1058 \\
 \label{sec:\secname:metrics}
 
 In order to assess the ability of LSST to 1) identify and 2) classify
-Young Stellar Objects we need to quantify the variability timescales and amplitudes of
-both Class I/II (stars with disks, including Classical T Tauris) and Class III (Weak-line T Tauris). 
-Inclusion of eruptive variables (FUor/EXor) is appropriate as well.
+Young Stellar Objects we need to quantify the variability timescales
+and amplitudes of both Class I/II (stars with disks, including
+Classical T Tauris) and Class III (Weak-line T Tauris).  Inclusion of
+eruptive variables (FUor/EXor) is appropriate as well.
 
-In brief, WTTS are quasi-periodic with amplitudes of 0.1 to 0.3 mag
-and periods 1 to $\sim$15 days, so their variability is comparable to 
-that of $\gamma$ Dor stars. Given the temporal evolution of cool spots, a
-period recovery analysis such as shown for RR Lyrae stars is likely difficult. 
-The embedded systems and CTTS are irregular variables but have been shown 
-to have distinctive colors due to
-extinction and the ultraviolet and blue excess arising from accretion shocks.
+In brief, Weak-line T-Tauris are quasi-periodic with amplitudes of 0.1
+to 0.3 mag and periods 1 to $\sim$15 days, so their variability is
+comparable to that of $\gamma$ Dor stars. Given the temporal evolution
+of cool spots, a period recovery analysis such as shown for RR Lyrae
+stars is likely difficult.  The embedded systems and Classical T
+Tauris are irregular variables but have been shown to have distinctive
+colors due to extinction and the ultraviolet and blue excess arising
+from accretion shocks.
 
 % --------------------------------------------------------------------
 
 \subsection{OpSim Analysis}
 \label{sec:\secname:analysis}
 
-OpSim analysis: how good would the default observing strategy be, at
-the time of writing for this science project?
+%OpSim analysis: how good would the default observing strategy be, at
+%the time of writing for this science project?
 
-{\bf This is pending on MAF work.}
+\new{WIC - Table \ref{table:pseudoForExor} shows a possible Figure of Merit for the recovery by LSST of the distribution of EXor high-state duration in outburst.}
+\begin{table}
+\small
+\begin{tabular}{c p{12cm}}
+& {\it Figure of Merit for recovery of EXor high--state duration distribution}\\
+\hline
+1.  & Produce ASCII lightcurve for eruptive outburst \\
+2.  & Initialise large array to store the maps of fraction detected as a function of duration and amplitude. \\
+2.  & for {\it duration} in range \{min, max\}:  \\
+3.  & ~~~~ for {\it amplitude} in range \{min, max\}: \\
+4.  & ~~~~~~~~~~ run {\tt mafContrib/transientAsciiMetric} \\
+5.  & ~~~~~~~~~~ store the spatial map of the fraction detected \\
+6.  & Initialise master arrays to hold the run of duration distribution measurements.\\
+7.  & for {\it iDraw} in range \{1, nDraws\}:\\
+8.  & ~~~~ construct model population with input duration distribution \\
+9.  & ~~~~ Apply the stored metrics from 2-5 to measure fraction recovered \\
+10.  & ~~~~ Characterize the duration distribution for this draw \\
+11. & ~~~~ Fill the {\it iDraw}'th entry in the master arrays. \\
+12. & {\bf FoM 1:} Compute the median and variance of the upper/lower quintiles. \\
+13. & {\bf FoM 2:} Evaluate the bias between recovered and input high-state duration. \\
+\hline
+\end{tabular}
+\caption{\new{Pseudocode for Figure of Merit recovering the distribution
+  for the duration of EXor high states. See Section \ref{sec:MW_SFH:targets} }}
+\label{table:pseudoForExor}
+\end{table}
+
 
 
 % --------------------------------------------------------------------
@@ -169,14 +182,16 @@ the time of writing for this science project?
 \subsection{Discussion}
 \label{sec:\secname:discussion}
 
-Galactic star formation regions are largely found at low Galactic latitudes or within 
-the Gould Belt structure. As such study of young stars with LSST is closely tied to other
-science goals concerning the Milky Way Disk and is subject to the concerns of both
-crowded field photometry and the observing cadence along the Milky Way.
+Galactic star formation regions are largely found at low Galactic
+latitudes or within the Gould Belt structure. As such study of young
+stars with LSST is closely tied to other science goals concerning the
+Milky Way Disk and is subject to the concerns of both crowded field
+photometry and the observing cadence along the Milky Way.
 
-The embedded and Classical T Tauri stars also undergo significant and rapid color changes
-due to accretion processes. The ability of LSST to track these variations in color could
-be limited by the interval between filter changes.
+The embedded and Classical T Tauri stars also undergo significant and
+rapid color changes due to accretion processes. The ability of LSST to
+track these variations in color could be limited by the interval
+between filter changes.
 
 % ====================================================================
 

--- a/whitepaper/MilkyWay/MW_SFH.tex
+++ b/whitepaper/MilkyWay/MW_SFH.tex
@@ -156,21 +156,22 @@ from accretion shocks.
 \hline
 1.  & Produce ASCII lightcurve for eruptive outburst \\
 2.  & Initialise large array to store the maps of fraction detected as a function of duration and amplitude. \\
-2.  & for {\it duration} in range \{min, max\}:  \\
-3.  & ~~~~ for {\it amplitude} in range \{min, max\}: \\
+2.  & for {\it duration T} in range \{min, max\}:  \\
+3.  & ~~~~ for {\it amplitude A} in range \{min, max\}: \\
 4.  & ~~~~~~~~~~ run {\tt mafContrib/transientAsciiMetric} \\
-5.  & ~~~~~~~~~~ store the spatial map of the fraction detected \\
+5.  & ~~~~~~~~~~ store the spatial map of the fraction detected for this (A, T) pair \\
 6.  & Initialise master arrays to hold the run of duration distribution measurements.\\
-7.  & for {\it iDraw} in range \{1, nDraws\}:\\
-8.  & ~~~~ construct model population with input duration distribution \\
-9.  & ~~~~ Apply the stored metrics from 2-5 to measure fraction recovered \\
-10.  & ~~~~ Characterize the duration distribution for this draw \\
-11. & ~~~~ Fill the {\it iDraw}'th entry in the master arrays. \\
-12. & {\bf FoM 1:} Compute the median and variance of the upper/lower quintiles. \\
-13. & {\bf FoM 2:} Evaluate the bias between recovered and input high-state duration. \\
+7. & Produce distribution of high--state durations and amplitudes from which the simulations will be drawn. \\
+8.  & for {\it iDraw} in range \{1, nDraws\}:\\
+9.  & ~~~~ construct model population with input duration distribution \\
+10.  & ~~~~ Apply the stored metrics from 2-5 to measure fraction recovered \\
+11.  & ~~~~ Characterize the duration distribution for this draw \\
+12. & ~~~~ Fill the {\it iDraw}'th entry in the master arrays. \\
+13. & {\bf FoM 1:} Compute the median and variance of the upper/lower quintiles. \\
+14. & {\bf FoM 2:} Evaluate the bias between recovered and input high-state duration. \\
 \hline
 \end{tabular}
-\caption{\new{Pseudocode for Figure of Merit recovering the distribution
+\caption{\new{Steps for Figure of Merit recovering the distribution
   for the duration of EXor high states. See Section \ref{sec:MW_SFH:targets} }}
 \label{table:pseudoForExor}
 \end{table}


### PR DESCRIPTION
I have edited the material on star formation contributed by @pmmcgehee to the MW chapter, mostly for compliance with the structure of the Whitepaper. There is an open question (Issue #321 ) about whether this should all be merged into Chapter 5.6, also on Star Formation through Variability, which we will hopefully resolve soon. Specific edits to the contributed MW_SFH.tex:

1.  Paragraphs that also appeared in the LSST Science Book (I believe Section 8.10.2) have been removed from MW_SFH.tex.

2. Some reordering to make content flow with the section template, and some minor rewording.

3. I have added a Table giving possible pseudocode for a Figure of Merit for the EXor stars. Expert input is needed! 

@akvivas @lmwalkowicz @AshishMahabal @phartigan @pmmcgehee 
