### PR TITLE
WFIRST WL: added notes on using the DE FoM, tried to articulate need for speed

### DIFF
--- a/whitepaper/WFIRST/WFIRST_weaklensing.tex
+++ b/whitepaper/WFIRST/WFIRST_weaklensing.tex
@@ -31,7 +31,7 @@ but there is a wide range of ancillary science that will be possible
 with the publicly available WFIRST HLS data (see for instance, the SDT
 report mentioned above).  However, the requirements on the HLS are
 largely set by constraints from weak lensing measurements.  Each galaxy
-in the WFIRST weak lesing survey needs to have an accurate photometric
+in the WFIRST weak lensing survey needs to have an accurate photometric
 redshift.  This requires optical photometry that reaches the depth of
 the NIR photometry WFIRST will acquire ($J~27AB$).  \emph{Thus, the
 WFIRST weak lensing survey will require the full  10-year LSST depth in
@@ -48,7 +48,7 @@ Thus, the WFIRST photometric data will help to provide better LSST
 photo-zs and  WFIRST will also provide many of the spectra needed as a
 training set to calibrate the photo-zs for both missions.  A further
 benefit to LSST might be the reduced need for LSST observations at the
-reddest end of the LSST wavelength range (the z and y filters), where
+reddest end of the LSST wavelength range (the $z$ and $y$ filters), where
 both the atmosphere and the physics of CCDs make ground-based
 observations less efficient than what WFIRST can achieve. Further work is needed to quantify this benefit, especially as the WFIRST proposed filter set is evolving.Finally, the
 joint processing of LSST and WFIRST data will provide better object
@@ -57,10 +57,24 @@ to provide a morphological prior for the deblending of LSST images.
 
 % --------------------------------------------------------------------
 
-\subsection{Target measurements and discoveries}
+\subsection{Measuring Dark Energy Parameters}
 \label{sec:\secname:targets}
 
-We propose an acceleration of the LSST survey over about $10\%$ of the
+The goal in this science project would be to measure Dark Energy parameters from various weak lensing
+probes, capitalizing on the improved photometric redshifts that a joint
+analysis of LSST and WFIRST photometry would provide. A useful
+Figure of Merit is the usual Dark Energy Task Force figure of merit,
+quantifying the available precision on the equation of state
+parameters $w_0$ and $w_a$. For example, we are interested in
+improvements in the weak lensing DE FoM as the LSST photometric redshifts
+and galaxy shapes are improved over the whole LSST survey area
+via joint analysis with WFIRST. We are also interested in increasing the
+WFIRST DE FoM as quickly as possible.
+Indeed, the basic problem we face is one of timing: being able to combine
+the WFIRST data with the LSST sooner will accelerate the production of
+cosmological results.
+
+Therefore, we propose an acceleration of the LSST survey over about $10\%$ of the
 LSST survey area (the $\sim2200$ WFIRST HLS) such that the full LSST ten
 years survey depth is reached on a timescale that maximizes the joint
 usefulness of LSST and WFIRST data on that area.  Assuming the two year
@@ -80,21 +94,14 @@ coordination of the locations of the accelerated LSST area and the
 WFIRST HLS. As LSST and WFIRST progress, there is a mutual benefit in
 continuing discussions about the optimal joint observation schedule.
 
-%It is possible that the WFIRST data might allow for shallower LSST data
-%in the reddest LSST filter in the overlap region, and this must be
-%quantified.
 
-
-% --------------------------------------------------------------------
-
-\subsection{Metrics}
-\label{sec:\secname:metrics}
-
-A simple, first order metric would be the amount of LSST/WFIRST
+A simple, first order diagnostic metric would be the amount of LSST/WFIRST
 overlapping survey area that reaches the full LSST depth when the WFIRST
 HLS is completed.  Such a metric is straightforward, but not
-quantitative until the 2020s, when the WFIRST launch date and survey
-plan is more definite.  A slightly more complicated metric could include
+able to be meanigfully encoded until the 2020s, when the WFIRST launch date and survey
+plan is more definite.  Strawman survey plans could, however, be
+evaluated to help with LSST schedule planning.
+A slightly more complicated metric could include
 the pace at which the overlapping LSST/WFIRST survey areas are both
 taken to full depth, since this would make each data set maximally
 useful to the US community (or anyone with immediate access to both
@@ -124,7 +131,9 @@ depth over the WFIRST HLS after 10 years of survey ($\sim2032$).
 
 Increasing the cadence of the LSST survey over $\sim10\%$ of the LSST
 survey has science benefits that go far beyond the LSST/WFIRST synergy
-described here.  There are benefits to certain aspects of time-domain
+described here: an observing strategy that met the joint WFIRST/LSST cosmology goals could
+also provide the kind of ``rolling cadence'' favored by other science teams.
+There are benefits to certain aspects of time-domain
 science.  Every effort should be made to coordinate all discussions of
 increased survey cadence (resulting in full LSST depth well before 10
 years) over sub-areas of the LSST survey footprint.  Specific attention


### PR DESCRIPTION
See what you think, @jasondrhodes - the changes I made are best viewed [here](https://github.com/LSSTScienceCollaborations/ObservingStrategy/pull/413/files), in the "Files Changed" section of this pull request. Your WL section did not say what your Figure of Merit is, but I think it's clear that its the DETF one (because the thing you are after is Dark Energy parameters). It seems as though the main reason you want to accelerate the LSST survey strategy is to get cosmology results out sooner, is that correct? Are there gains in final accuracy that could be made by having LSST image the WFIRST HLS area in advance of WFIRST?