### PR TITLE
4.2: implemented ebellm suggested edits; other minor typos

### DIFF
--- a/whitepaper/MilkyWay/MW_Disk.tex
+++ b/whitepaper/MilkyWay/MW_Disk.tex
@@ -23,8 +23,9 @@ the only facility in the forseeable future that will be able to
 identify a statistically meaningful sample. Some (such as the novae
 that allow detailed study of the route to Type Ia Supernovae) offer
 unique laboratories to study processes of fundamental importance to
-astrophysics at all scales. Others (like intra-disk microlensing
-events) offer the {\it only} probe of important populations.
+astrophysics at all scales. Others \new{(like slow-microlensing events
+  heralding an unseen compact object population)} offer the {\it only}
+probe of important populations.
 
 %An important collateral benefit of studies in the plane with an
 %LSST-like facility, is improved mapping of the distribution and
@@ -195,15 +196,19 @@ data leading up to the event---but only if LSST covers the Plane at a
 frequent cadence. Just {\it how} frequent is open to exploration at
 present, but the prospect of high-sensitivity observations of the
 location of such a supernova {\it before} it takes place are clearly
-of enormous scientific value. A secondary issue is the prospect that
-an easily-observed Milky Way supernova might be too bright for LSST to
-measure precisely with its planned exposure time, with a roughly 82\%
-chance of a core-collapse supernova reaching one or two magnitudes
-brighter than LSST's nominal saturation limit \citep[with a 1/3 chance that
-a ccSN would reach $m_V \sim 5$;][]{2013ApJ...778..164A}. For a Type Ia in
-the Milky Way,
-\citet{2013ApJ...778..164A} estimate $m_{V, max} \lesssim 13.5$~in 92\% of
-cases.
+of enormous scientific value. 
+
+% WIC 2016-06-03 - removed following feeback
+
+%A secondary issue is the prospect that
+%an easily-observed Milky Way supernova might be too bright for LSST to
+%measure precisely with its planned exposure time, with a roughly 82\%
+%chance of a core-collapse supernova reaching one or two magnitudes
+%brighter than LSST's nominal saturation limit \citep[with a 1/3 chance that
+%a ccSN would reach $m_V \sim 5$;][]{2013ApJ...778..164A}. For a Type Ia in
+%the Milky Way,
+%\citet{2013ApJ...778..164A} estimate $m_{V, max} \lesssim 13.5$~in 92\% of
+%cases.
 
 {\bf 4. Population parameters of planets beyond the Snow Line with
   Microlensing:} \citet{gould13}  shows that, LSST could contribute a
@@ -316,13 +321,13 @@ Since (at the time of writing) evaluating a Metric with relaxed
   observatories) the metric choice for detectability should take the
   lightcurve shape into account.
 
-The main innovation required before this FoM can be run, is the
-  extension of existing periodic Metrics to cases with a lightcurve
-  shape more complicated than a sine plus noise. The {\tt
-    TransientAsciiMetric} may be a good place to start; or, it might
-  be straightforward to extend {\tt periodicStarFit} to lightcurves
-  with more than one Fourier coefficient. Or, an entirely new metric
-  might be written including more Fourier terms in the fit.
+\new{We envisage two levels to implementing FoM 1.1. In the immediate
+  future, the ellipsoidal lightcurve could be characterised as a
+  sinusoid, with filter-dependent amplitude to match typical quiescent
+  Low Mass X-ray Binaries (qLMXBs) from the literature. The next level
+  of sophistication would be to input a more complicated shape that
+  captures deviations from pure sine-wave behavior; likely with the {\tt
+    TransientAsciiMetric}. }
 
 An open question is how best to meaningfully quantify the
   recovery fraction of a population with a wide range in binary
@@ -330,14 +335,16 @@ An open question is how best to meaningfully quantify the
   ``average'' population will allow direct comparison between
   observing strategies.
 
-{\it Possible higher-order FoM:} errors on the population size (mass
-function?) derived from a survey under a given observing
-strategy. Can imagine just adding up the ``recovered'' qLMXB
-population and comparing it to that simulated. Some white noise
-componant of varying strengths could be added to the light curves to
-simulate various contributions of the accretion disk to the continuum
-light.  Note that the survey will necessarily be highly incomplete
-(inclination effects, etc.), it is the likely {\it uncertainty} on the
+{\it Possible higher-order FoM:} A higher-order FoM for the fraction
+of qLMXBs recovered might take the form of the uncertainty on the
+population size (or physical population parameter like mass function
+slope) derived from a survey under a given observing strategy. One can
+imagine summing the ``recovered'' qLMXB population count and comparing
+it to that simulated. Some white noise componant of varying strengths
+could be added to the light curves to simulate various contributions
+of the accretion disk to the continuum light.  Note that the survey
+will necessarily be highly incomplete (due to inclination effects,
+etc.), it is the likely {\it uncertainty} on the
 completeness-correction that would be crucial in this case.
 
 \begin{table}[h]
@@ -346,10 +353,10 @@ completeness-correction that would be crucial in this case.
     & {\it FoM 1.1 - Fraction of quiescent black hole binaries (qLMXB) detectable by LSST through ellipsoidal variability} \\
     \hline
   1. & Pick a typical binary mass ratio and separation for $qLMXB$ \\
-  2. & Identify typical ellipsoidal variation amplitude and period \\
-  3. & Represent as Fourier terms or ASCII lightcurve \\
-  4. & Run a variant of {\tt periodicStarFit.ipynb} that allows the appropriate double-humped lightcurve shape. May be appropriate to modify {\tt mafContrib/periodicStarMetric.py}. \\
-  5. & {\bf Arrive at FoM 1.1:} Load the result from 4. and sum over the spatial region (to be determined: Galactic Latitude range? Comparison high-latitude clusters?) where the qLMXBs are expected.\\
+  2. & Identify typical ellipsoidal variation amplitude and period, for each filter \\
+  3a. & {\it Near-term:} Run {\tt periodicStarMetric} to determine the fraction of typical qLMXBs that would be recovered. Or; \\
+  3b. & Run a variant of {\tt periodicStarFit.ipynb} that allows the appropriate double-humped lightcurve shape. \\
+  4. & {\bf Arrive at FoM 1.1:} Load the result from 4. and sum over the spatial region (to be determined: Galactic Latitude range? Comparison high-latitude clusters?) where the qLMXBs are expected.\\
 \hline
     \end{tabular}
  \caption{Description of Figure of Merit 1.1.}
@@ -402,8 +409,8 @@ completeness-correction that would be crucial in this case.
   \label{table:pseudoFOM_1p2}
 \end{table}
 
-{\it Possible higher-order FoM:} Uncertainty in LIGO event rates due
-to uncertainties in common envelope evolution, which drives
+{\it Possible higher-order FoM:} The uncertainty in LIGO event rates
+due to uncertainties in common envelope evolution, which drives
 uncertainties in both LIGO event rates and DN population.
 
 %Dependencies:
@@ -429,9 +436,8 @@ In the longer term, a Monte Carlo simulation could be run on a particular class 
   4. & {\bf Arrive at FoM 2.1b:} Multiply the result of 2. by the result of the {\tt Starcounts} metric. Sum this to find the fraction of Novae recovered if their spatial density follows the stellar density in the Milky Way. \\
   \hline
   5. & From the typical lightcurve and a typical follow-up scenario, determine the time interval before outburst peak that would be required to schedule followu-up observations;\\
-  6. & Use these to produce the time interval parameters for the {\tt TripletMetric}; \\
-  7. & Run {\tt TripletMetric.py}; \\
-  8. & {\bf Arrive at FoM 2.2:} Sum the result of step 6. over the spatial region of interest.\\
+  6. & Use these to produce appropriate parameters for a transient metric that returns the fraction of events detected; \\
+  7. & {\bf Arrive at FoM 2.2:} Sum the result of step 6. over the spatial region of interest.\\
 \hline
     \end{tabular}
  \caption{Description of Figures of Merit 2.1. \& 2.2.}
@@ -439,8 +445,9 @@ In the longer term, a Monte Carlo simulation could be run on a particular class 
 \end{table}
 
 
-{\it Possible higher-order metrics:} Error on the rate of Type Ia
-supernovae using LSST data taken under various observing strategies.
+{\it Possible higher-order metrics:} Uncertainty on the specific rate
+of Type Ia supernovae using LSST data taken under various observing
+strategies.
 
 %Dependencies:
 %\begin{itemize}
@@ -483,7 +490,7 @@ sightline, $N_{\ast,i}$~the number of stars present along the $i$'th
 sightline, and the FoM is normalized by the total number of stars
 returned by the density model over all sightlines. (For the OpSim
 runs tested here, \opsimdbref{db:baseCadence} and
-\opsimdbref{db:opstwoPS}, the normalization factors differ by $\sim
+\opsimdbref{db:opstwoPS} and \opsimdbref{db:NormalGalacticPlane}, the normalization factors differ by $\sim
 2\%$.) FoM values are in the range $0.0 \le FoM_{preSN} \le 1.0$.
 
 We assume the Pre-SN variability similar to the pre-SN outburst of
@@ -565,7 +572,7 @@ sight-line.\footnote{The notebooks used to evaluate this version of
      & ~~~ Scaling from 3. might be used in conjunction with {\tt maf\_contrib/starcounts}; \\
   5. & Run the transient-recovery metric for this population; \\
      & ~~~ Choice of metric needs to handle spatially varying lightcurve template; \\
-     & ~~~ Or, with {\tt TripletMetric} or similar, the time-interval parameters should be allowed to spatially vary; \\
+     & ~~~ Or, the time-interval parameters should be allowed to spatially vary; \\
   6. & Determine the population of microlens planets that would have been triggered by LSST. Do not sum, but record the indices of the surviving objects; \\
   7. & Apply typical measurement uncertainty from a likely followup campaign; \\
   8. & Fit the determined mass function from this sample of survivors only; \\
@@ -620,7 +627,7 @@ For comparison, when run on 2015-era OpSim runs {\tt enigma\_1189}
 (Baseline strategy) and {\tt ops2\_1092} (PanSTARRS-like strategy) the
 results were 0.251 (Baseline) and 0.852 (PanSTARRS-like strategy). So
 the 2016-era OpSim runs show a sharper disadvantage than before to the
-Baseline cadence for the Galactic Supernova case.} Because \opsimdbref{db:opstwoPS} spends no time at all on certain regions of interest (like the South Polar cap and the Northern plane), it might be artificially advantaged over the Baseline survey. A more direct comparison is afforded by the recently-completed (at the time of writing) OpSim run {\tt astro\_lsst\_01\_1004}, which covers the same regions on the sky as \opsimdbref{db:baseCadence} but applies the Wide-Fast-Deep strategy to the inner Galactic Plane. That strategy still shows a strong advantage compared to the Baseline survey, with $FoM_{preSN}$({\tt astro\_lsst\_01\_1004})=0.73, compared to 0.13 for Baseline cadence. See Table \ref{tab_SummaryMWDisk}. Figure \ref{f_opSim_GalacticSN} presents a breakdown of this figure of merit across sightlines, for the three observing strategies considered.
+Baseline cadence for the Galactic Supernova case.} Because \opsimdbref{db:opstwoPS} spends no time at all on certain regions of interest (like the South Polar cap and the Northern plane), it might be artificially advantaged over the Baseline survey. A more direct comparison is afforded by the recently-completed (at the time of writing) OpSim run \opsimdbref{db:NormalGalacticPlane}, which covers the same regions on the sky as \opsimdbref{db:baseCadence} but applies the Wide-Fast-Deep strategy to the inner Galactic Plane. That strategy still shows a strong advantage compared to the Baseline survey, with $FoM_{preSN}$(\opsimdbref{db:NormalGalacticPlane})=0.73, compared to 0.13 for Baseline cadence. See Table \ref{tab_SummaryMWDisk}. Figure \ref{f_opSim_GalacticSN} presents a breakdown of this figure of merit across sightlines, for the three observing strategies considered.
 
 \begin{figure}
 \begin{center}
@@ -634,7 +641,7 @@ Baseline cadence for the Galactic Supernova case.} Because \opsimdbref{db:opstwo
   broken down by sightline. $FoM_{preSN}$~is estimated for
   three OpSim runs (to-date); \opsimdbref{db:baseCadence} (left; Baseline
   cadence), \opsimdbref{db:opstwoPS} (center; PanSTARRS-like
-  strategy), and {\tt astro\_lsst\_01\_1004} (which assigns Wide-Fast-Deep cadence to the inner Galactic Plane). The normalizing factors $N_{\ast, total}$ are $3.793 \times 10^{10}$~for both \opsimdbref{db:baseCadence} and {\tt astro\_lsst\_01\_1004} (that both strategies have the same $N_\ast$~is not a surprise since both cover the same area) and $3.692\times
+  strategy), and \opsimdbref{db:NormalGalacticPlane} (which assigns Wide-Fast-Deep cadence to the inner Galactic Plane). The normalizing factors $N_{\ast, total}$ are $3.793 \times 10^{10}$~for both \opsimdbref{db:baseCadence} and \opsimdbref{db:NormalGalacticPlane} (that both strategies have the same $N_\ast$~is not a surprise since both cover the same area) and $3.692\times
   10^{10}$~for \opsimdbref{db:opstwoPS}. The imprint of reduced sampling towards
   the inner plane can be clearly seen for \opsimdbref{db:baseCadence}.
   Notice the difference in color scale between the panels. See \autoref{sec:MW_Disk:MW_Disk_analysis}}
@@ -669,6 +676,18 @@ baseline (see \autoref{fig_astrom_ByTime_pmError} of
 \autoref{sec:MW_Astrometry:MW_Astrometry_OpSim} for a demonstration applied to
 proper motions).
 
+\new{Whether the Plane should be observed as a ``special survey'' or
+  as part of Wide-Fast-Deep, remains an open question that we expect
+  the Figures of Merit (FoM) to answer when fully implemented. For
+  example, one can imagine reducing observing time in $u$~(and
+  possibly $g$) bands towards heavily extincted regions at the lowest
+  galactic latitudes. The scientific impact of such a strategy
+  (e.g. possibly lower sensitivity to directly-detected compact
+  objects versus improved coverage for transients in general) should
+  become clear when implementation and evaluation of the FoMs
+  described in this Section are complete.}
+
+
 %We have proposed an OpSim run that includes the Galactic Plane in the
 %deep-wide-fast survey:
 
@@ -676,7 +695,7 @@ proper motions).
 
 \begin{table}
   \begin{tabular}{l|p{6cm}|c|c|c|c|p{5cm}}
-    FoM & Brief description & {\rotatebox{90}{\opsimdbref{db:baseCadence}}} & {\rotatebox{90}{\opsimdbref{db:opstwoPS}}} & {\rotatebox{90}{\scriptsize{\tt astro\_lsst\_01\_1004}  }} &  {\rotatebox{90}{future run 2}} & Notes \\
+    FoM & Brief description & {\rotatebox{90}{\opsimdbref{db:baseCadence}}} & {\rotatebox{90}{\opsimdbref{db:opstwoPS}}} & {\rotatebox{90}{\opsimdbref{db:NormalGalacticPlane}  }} &  {\rotatebox{90}{future run 2}} & Notes \\
     \hline
     1.1 & \footnotesize{LMXB ellipsoidal variations}      & - & - & - & - & - \\
     1.2 & \footnotesize{Uncertainty in dwarf nova duty cycle}   & - & - & - & - &  \footnotesize{LSST as initial trigger} \\
@@ -688,7 +707,7 @@ proper motions).
 %    5.1a & \footnotesize{Median (over sight-lines) of the uncertainty in $E(B-V)$} & - & - & - & - & \footnotesize{(Most useful FoM probably a spatial map of the uncertainty.)} \\
 %    5.1b & \footnotesize{Variance (over sight-lines) of the uncertainty in $E(B-V)$} & - & - & - & - & - \\
   \end{tabular}
-\caption{Summary of figures-of-merit for the Galactic Disk science cases. The best value of each FoM is indicated in bold. Runs \opsimdbref{db:baseCadence} and \opsimdbref{db:opstwoPS} refer to the Baseline and PanSTARRS-like strategies, respectively. Column {\tt astro\_lsst\_01\_1004} refers to a recently-completed OpSim run that includes the Plane in Wide-Fast-Deep observations. See \autoref{sec:MW_Disk:MW_Disk_analysis}. }
+\caption{Summary of figures-of-merit for the Galactic Disk science cases. The best value of each FoM is indicated in bold. Runs \opsimdbref{db:baseCadence} and \opsimdbref{db:opstwoPS} refer to the Baseline and PanSTARRS-like strategies, respectively. Column \opsimdbref{db:NormalGalacticPlane} refers to a recently-completed OpSim run that includes the Plane in Wide-Fast-Deep observations. See \autoref{sec:MW_Disk:MW_Disk_analysis}. }
 \label{tab_SummaryMWDisk}
 \end{table}
 


### PR DESCRIPTION
See Issue #428 

@ebellm 's main suggestions have been implemented. The two new paragraphs this produced are highlighted blue, I will de-highlight them before the end of the daty (06/03).

Additionally, replaced astro_lsst_01_1004 --> opsimdbref{db:NormalGalacticPlane}

cc @cbritt4 @caprastro @chomiuk @akvivas 
