### PR TITLE
Low-cadence WFIRST+LSST microlensing

### DIFF
--- a/whitepaper/WFIRST/WFIRST_microlensing.tex
+++ b/whitepaper/WFIRST/WFIRST_microlensing.tex
@@ -19,15 +19,16 @@
 
 \credit{davidpbennett},
 \credit{mtpenny},
+\credit{poleski},
 {\it Rachel Street}.
 
 Perhaps the most exciting discovery to come out of gravitational
 microlensing surveys is the discovery of a large population of ``rogue"
-planets by the MOA Collaboration (Sumi et al.\ 2011). These planets
+planets by the MOA Collaboration \citep{2011Natur.473..349S}. These planets
 are isolated in the sense that no host star can be detected
 by microlensing. Depending on the peak magnification and light curve
-coverage, this can imply that a host must be $> 10\,$AU or $> 100\,$AU,
-and Bennett et al.\ (2012) have argued that the median separation
+coverage, this can imply that a host must be $> 10\,$AU or $> 100\,$AU away,
+and \citet{2012ApJ...757..119B} have argued that the median separation
 of possible host stars is likely to be $> 30\,$AU.
 Further observations by both the MOA and OGLE collaborations provide
 a qualitative confirmation of this result, as dozens of additional
@@ -39,14 +40,14 @@ and OGLE samples.
 A major weakness with the microlensing data that indicates this
 large population of rogue planets is that, thus far, the properties
 of this population have only been inferred by their Einstein radius
-crossing time, $t_E$, distribution. But, the Einstein radius crossing
+crossing time, $t_{rm E}$, distribution. But, the Einstein radius crossing
 time depends not only on the lens mass, but also on its distance and
 transverse velocity. As a result, we cannot directly infer the mass or distance
 distribution of the rogue planet sample.
 
 Our understanding of the rogue planet distribution can be greatly improved
-by measuring the microlensing parallax effect (Gould et al.\ 1992;
-Alcock et al.\ 1995). The microlensing parallax effect can be described
+by measuring the microlensing parallax effect \citep{1992ApJ...392..442G,1995ApJ...454L.125A}. 
+The microlensing parallax effect can be described
 by the transverse relative lens-source velocity, ${\bf v}_{\rm \perp}$, projected
 to the position of the observer,
 \begin{equation}
@@ -55,15 +56,15 @@ to the position of the observer,
 where $D_L$ and $D_S$ are the lens and source distances, respectively.
 Typically, microlensing parallax
 is measured using the orbital motion of the Earth, but it can also be
-measured using light curve observations from telesopes at different locations
-in the Solar System (Dong et al.\ 2007; Calchi Novati et al.\ 2015) or
-even different locations on Earth (Gould et al.\ 2009). However, in the
+measured using light curve observations from telescopes at different locations
+in the Solar System \citep{2007ApJ...664..862D,2015ApJ...804...20C} or
+even different locations on Earth \citep{2009ApJ...698L.147G}. However, in the
 case of microlensing by planetary mass objects, the event durations are
 too short to allow a significant light curve change due to the Earth's
 orbital motion, but the near simultaneous observations from Earth and a
 satellite orbiting at the Earth-Sun L2 point (where WFIRST will orbit) does
 allow the measurement of microlensing parallax signals due to planetary mass
-lenses (Gould, Gaudi \& Han, 2003).
+lenses \citep{2003ApJ...591L..53G}.
 
 When a microlensing parallax signal is measured, the $\tilde{\bf v}$ value
 can generally distinguish between bulge and disk lenses, as $\tilde{\bf v}$
@@ -73,7 +74,7 @@ disk, while for a lens in the bulge, the magnitude of the projected velocity
 is $\tilde{v} \gtsim 200\,$km/sec. A microlensing parallax measurement also
 yields a mass distance relationship,
 \begin{equation}
-   M_L = {\tilde{v}^2 t_E^2 c^2 \over 4 G} {D_S-D_L \over D_L D_S} \ .
+   M_L = {\tilde{v}^2 t_{rm E}^2 c^2 \over 4 G} {D_S-D_L \over D_L D_S} \ .
    \label{eq-m_vt}
 \end{equation}
 Because the $\tilde{\bf v}$ value places a fairly strong constraint
@@ -83,16 +84,16 @@ events, we can do even better. For high magnification events or events
 with low-mass lenses, the finite angular size of the source star is
 resolved, and the light curve provides a measurement of the source
 radius crossing time, $t_*$. This allows the angular Einstein radius
-to be determined, $\theta_E = t_E \theta_*/t_*$, where the angular
+to be determined, $\theta_{rm E} = t_{rm E} \theta_*/t_*$, where the angular
 source radius, $\theta_*$ can be determined from the color and brightness
-of the source star (Boyajian et al.\ 2014). When both $\tilde{v}$ and
-$\theta_E$, the mass of the lens is measured to be
+of the source star \citep{2014AJ....147...47B}. When both $\tilde{v}$ and
+$\theta_{rm E}$ are known, the mass of the lens is measured to be
 \begin{equation}
-M_L = {c^2\over 4G} \tilde{v} t_E \theta_E = {\theta_E\tilde{v} t_E \over (8.1439\,{\rm mas\, AU})} M_{\odot} \ .
+M_L = {c^2\over 4G} \tilde{v} t_{rm E} \theta_{rm E} = {\theta_{rm E}\tilde{v} t_{rm E} \over (8.14\,{\rm mas\, AU})} M_{\odot} \ .
 \label{eq-m}
 \end{equation}
 Figure~\ref{fig-lc} shows an example of the light curves for one of the
-rougue planets with a mass determined by simultaneous WFIRST and LSST
+rogue planets with a mass determined by simultaneous WFIRST and LSST
 observations.
 
 \begin{figure}[t]
@@ -102,14 +103,42 @@ mass measurement from simultaneous WFIRST and LSST observations.
 \label{fig-lc}}
 \end{figure}
 
+WFIRST planetary microlensing events will greatly improve our 
+understanding of not only rogue planets population but also cold giants similar to
+Uranus or Neptune and smaller mass planets on wide orbits. Cold giants 
+cannot be studied using techniques other than microlensing and 
+WFIRST gives us a unique opportunity to detect a statistically significant 
+number of wide orbit planets. Even though the wide orbit planets will be detected, 
+their properties may not be well constrained by WFIRST or it may be hard to distinguish  
+between a wide orbit planet and a rogue planet, particularly for planets on the widest 
+orbits or when the source trajectory does not closely approach the host star.
+The two main parameters that can be derived for bound planets are 
+the mass ration, $q$, and the projected separation ,$s$, in units of Einstein radius. 
+Wide orbit planet adds an additional peak to the otherwise 
+standard microlensing light curve produced by the planet host. 
+The time separation of the two peaks, $\Delta t$, is directly related 
+to the planet projected separation:
+\begin{equation}
+ \Delta t =  t_{\rm E}(s - {1/s}) \ .
+\end{equation}
+Typical value of $t_{\rm E}$ is $25~{\rm days}$, hence, for a wide 
+separation planet ($s$ on the order of a few) $\Delta t$ will be 
+comparable to the length of a single WFIRST session i.e., $72~{\rm days}$.  
+Even though WFIRST will be able to observe the planetary anomaly, 
+it may not observe the host event and hence poorly constrain planet properties. Deep low-cadence LSST 
+monitoring of the WFIRST microlensing field over whole bulge observing season 
+will reveal the peaks of planet host microlensing events that are unobservable 
+to the WFIRST and will help to constrain projected separation and mass ratio. 
+
+
 % --------------------------------------------------------------------
 
 \subsection{A Proposed Observing Strategy}
 \label{sec:\secname:proposal}
 
 Based on the desiderata above, we
-propose simultaneous high cadence observations of the WFIRST microlensing fields
-(which should be covered by a single LSST pointing) by LSST during each
+propose simultaneous high cadence observations of the WFIRST microlensing fields 
+by LSST during each
 of the six 72-day WFIRST exoplanet microlensing survey sessions. These
 will allow microlensing parallax measurements to determine the distances
 and masses of a representative sub-sample of the rogue planets found by
@@ -119,32 +148,29 @@ cannot be obtained by another method.
 
 We also propose continuous monitoring of the WFIRST microlensing fields
 at a cadence of one observation per day
-starting a year before and ending a year after the WFIRST microlensing.
-This will allow us to search for microlensing signals of possible
-host stars for the detected rogue planet candidates. Such signals will
-appear as seperate microlensing signals long before or after the apparent
-rogue planetary signals. They cannot be detected by WFIRST due to the
-limited 72 day WFIRST observing windows.
+starting a year before and ending a year after the WFIRST microlensing survey. 
+This will allow us to constrain the presence of a host star for rogue planet candidates and, 
+if the host is detected, measure the planet-host mass ratio and projected separation. 
 
 A single LSST pointing, centered on the WFIRST microlensing
 fields, would cover all 10 WFIRST microlensing fields.
 
-For our preliminary estimates of the high cadence observing, we assume
+For our preliminary estimates of the high-cadence observing, we assume
 that the bulge is observed every 30 minutes when the bulge is at
 an airmass of $< 2.5$ for 76-day observing runs (each 72-day WFIRST observing
 season plus 2 days on either side). Each visit consists of 3 exposures,
 one 2 sec exposure followed by two 15 sec exposures. With a 2 sec readout
-and 1 sec for the shutter to open and close, this comes to 42 sec on target
+and 1 sec for the shutter to open and close, this comes to 39 sec on target
 per visit (since the final readout can be done while slewing).
-If we assume a 30 deg slew in Azimuth before and after each ML pointing, the slews
+If we assume a 30 deg slew in Azimuth before and after each microlensing pointing, the slews
 to and from the target should take 22 sec, which is 12 sec above the average. So,
-each observation will take 66 sec out of the regular observing sequence.
+each visit will take 61 sec out of the regular observing sequence.
 The number of observations per night, assuming a 30 minute cadence, for
-a Spring, 2025 observing session are given in \autoref{tab:wfirst_ml_survey}. We will require
+a Spring 2025 observing session are given in \autoref{tab:wfirst_ml_survey}. We will require
 that these observations be taken in the $riz$ or $y$ filters with at
 least 3 (or 0) observations in each filter per night. The total number
-of observations with this observing plan is 649 or 11.9 hour per
-72-day observing session or 3894 observations and 71.4 hours for
+of observations with this observing plan is 649 or 11.0 hour per
+76-day observing session or 3894 observations and 66.0 hours for
 all the high cadence observations that we propose.
 
 \begin{table}
@@ -169,37 +195,41 @@ WFIRST microlensing survey.}
 \label{tab:wfirst_ml_survey}
 \end{table}
 
-The low-cadence (1 observation per day) observations taken when WFIRST
-is not observing, would consist of 1270 observations if we assume that
-the observations are not taken during the time when the $u$ filter is
-on the telescope (this is assumed to be 1/6 of the time). The low-cadence
-off-season observations then total 23.3 hours, for a grand total of
-95.7 hours over 8 years.
-
 These observing plans can be altered by changing the cadence of the high
 cadence observations from once every 30 minutes to once every 15, 60,
 or 120 minutes, or we could change the number of WFIRST microlensing
 observing seasons that were covered. We have not yet simulated the
 different observing cadences, however.
 
+The low-cadence (1 observation per day) observations taken when WFIRST
+is not observing, would consist of 1270 visits if we assume that
+the observations are not taken during the time when the $u$ filter is
+on the telescope (this is assumed to be 1/6 of the time). The low-cadence
+off-season observations then total 21.5 hours. Low- and high-cadence 
+observations will take a total of 87.5 hours over 8 years.
+
+
+
 % --------------------------------------------------------------------
 
 \subsection{Metrics}
 \label{sec:\secname:metrics}
 
+\subsubsection{High-cadence observations}
+
 \autoref{tab:wfirst_ml_results}
 shows the results of our simulations of the combined proposed WFIRST-LSST
 observing program. We assume that there is 1 planet per main sequence
 star at each of $1\,M_\oplus$, $10\,M_\oplus$, and $100\,M_\oplus$.
-This is the 1-$\sigma$ lower limit found by Sumi et al.\ (2011) at
+This is the 1-$\sigma$ lower limit found by \citet{2011Natur.473..349S} at
 $M_L \approx 300\,M_\oplus$, and the rogue planet mass function is
 thought to increase toward lower masses, so this is a conservative
 assumption. The first row gives the number of events that will be
 observed by WFIRST. The second row gives the number of these events
-with SDSS-$i \leq 23$, which were the only events included in the
+with source SDSS-$i \leq 23$, which were the only events included in the
 LSST simulations. The third and fourth rows give the number of these events
 with LSST-WFIRST microlensing parallax measurements and the number
-with full mass measurements. It is these rows that indicate the
+with full mass measurements. It is this row that indicates the
 value of the LSST observations.
 
 \begin{table}
@@ -208,7 +238,7 @@ Category & $100\,M_\oplus$ & $10\,M_\oplus$ & $1\,M_\oplus$ & Total \\
 \hline
 WFIRST-events    &   417   &         127    &         33    &  577  \\
 $i \leq 23$      &    88   &          30    &         13    &  131  \\
-$\pi_E$ measured &    22   &           8.2  &          2.7  &   32.9 \\
+$\pi_{rm E}$ measured &    22   &           8.2  &          2.7  &   32.9 \\
 $M_L$ measured   &    5.9  &           3.4  &          1.5  &   10.8 \\
 \end{tabular}
 \caption{Number of rogue planets of the given mass detected, assuming
@@ -221,18 +251,47 @@ We can see from the final column that the LSST observations should
 yield more than 30 rogue planet microlensing parallax measurements and
 more than 10 rogue planet mass measurements.
 %
-These are measurements that cannot be made by other methods.
+These are measurements that cannot be made by other methods, as there is 
+currently no other known way to measure the mass distribution and abundance 
+of dark, isolated objects.
 % \textbf{THE PREVIOUS SENTENCE NEEDS MORE JUSTIFICATION.}
 %
 In addition, this program would
 also yield masses for a somewhat larger number of bound planets
-(Gould, Gaudi \& Han 2003), although many of these will have their
+\citep{2003ApJ...591L..53G}, although many of these will have their
 masses determined by other means as well.
 
 For a figure of merit, we select the product of the numbers of
-rogue planet microlensing parallax measurements $\pi_E$
-and rogue planet mass measurements $M_L$.
+rogue planet microlensing parallax measurements $\pi_{rm E}$
+and rogue planet mass measurements $M_L$. Some additional 
+work is still needed to test and develop this metric so that it can be easily incorporated into the MAF based on OpSim runs.
 The value of this product is 355 for our straw man program.
+
+
+\subsubsection{Low-cadence observations}
+
+LSST observations will improve models for WFIRST planetary events 
+in a number of ways but here we focus on detection of the planet 
+host peak if it was missed and poorly constrained by WFIRST. We simulate 
+a population of planets with masses of $0.1\,M_\oplus$, $1\,M_\oplus$, 
+and $10\,M_\oplus$ that follow logarithmic mass function with 
+normalization extrapolated from Cassan et al. (2012). We narrow the sample of 
+planets detected by WFIRST in a number of steps. First, we reject the events 
+with host peak during the LSST high-cadence observations, i.e., during one of six 
+76-day long campaigns. Second, we exclude the events with host event reaching 
+at least $0.75$ of the event maximum flux increase, because in these cases WFIRST 
+data will strongly constrain the host peak even though it is not fully observed. 
+Third, we require at least a single LSST observation within $\pm0.05t_{\rm E}$ of 
+the host peak and the magnified source flux to be brighter than SDSS-$z$ of $23~{\rm mag}$. 
+The expected number of $0.1\,M_\oplus$, $1\,M_\oplus$, and $10\,M_\oplus$ 
+planets for which host peak is detected are 2.1, 8.7, and 36.9, respectively. 
+We chose a sum of those as our figure of merit. For the observing strategy 
+presented above FoM is 47.7. If a maximum airmass is chosen to be 
+2.0 instead of 2.5, then the requested time decreases by $6\%$ and FoM decreases by $12\%$. 
+The metric is based solely on the distribution of peak times and source magnitudes 
+for a given WFIRST simulation, so once this is set, the metric can 
+be easily computed for any OpSim run.
+
 
 % Quantifying the response via MAF metrics: definition of the metrics,
 % and any derived overall figure of merit.
@@ -257,8 +316,8 @@ have proposed. We would hope to refine this analysis using the output
 of an `OpSim` run where the WFIRST+LSST microlensing program was included
 as an additional special survey, and our figure of merit coded in the
 MAF. We do not expect the impact of this special survey on other science cases
-to be high, needing as it would only 12 hours per year in total. The risk
-seems similar, but less high, than that of a Deep Drilling Field.
+to be high, as it would only need 12 hours per year in total. The risk
+seems similar, but smaller than that of a Deep Drilling Field.
 
 Other science teams may find it useful to think of the WFIRST+LSST microlensing
 survey as a medium deep drilling field located in the bulge: it would be interesting

--- a/whitepaper/authors.tex
+++ b/whitepaper/authors.tex
@@ -113,6 +113,7 @@
 \author{Eric Neilsen}{ehneilsen}{\somewhere}
 \author{Matthew T.\ Penny}{mtpenny}{Sagan Fellow,~\osu}
 \author{Christina Peters}{cmp346}{\drexel}
+\author{Rados{\l}aw Poleski}{poleski}{\osu}
 \author{Gordon Richards}{GordonRichards}{\drexel}
 \author{Stephen Ridgway}{StephenRidgway}{\noao}
 \author{Jeonghee Rho}{jhrlsst}{\seti}

--- a/whitepaper/references.bib
+++ b/whitepaper/references.bib
@@ -4222,3 +4222,228 @@ archivePrefix = "arXiv",
    adsurl = {http://adsabs.harvard.edu/abs/2016MNRAS.458.3012W},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
+
+@ARTICLE{2011Natur.473..349S,
+   author = {{Sumi}, T. and {Kamiya}, K. and {Bennett}, D.~P. and {Bond}, I.~A. and 
+	{Abe}, F. and {Botzler}, C.~S. and {Fukui}, A. and {Furusawa}, K. and 
+	{Hearnshaw}, J.~B. and {Itow}, Y. and {Kilmartin}, P.~M. and 
+	{Korpela}, A. and {Lin}, W. and {Ling}, C.~H. and {Masuda}, K. and 
+	{Matsubara}, Y. and {Miyake}, N. and {Motomura}, M. and {Muraki}, Y. and 
+	{Nagaya}, M. and {Nakamura}, S. and {Ohnishi}, K. and {Okumura}, T. and 
+	{Perrott}, Y.~C. and {Rattenbury}, N. and {Saito}, T. and {Sako}, T. and 
+	{Sullivan}, D.~J. and {Sweatman}, W.~L. and {Tristram}, P.~J. and 
+	{Udalski}, A. and {Szyma{\'n}ski}, M.~K. and {Kubiak}, M. and 
+	{Pietrzy{\'n}ski}, G. and {Poleski}, R. and {Soszy{\'n}ski}, I. and 
+	{Wyrzykowski}, {\L}. and {Ulaczyk}, K. and {Microlensing Observations in Astrophysics (MOA) Collaboration}
+	},
+    title = "{Unbound or distant planetary mass population detected by gravitational microlensing}",
+  journal = {\nat},
+archivePrefix = "arXiv",
+   eprint = {1105.3544},
+ primaryClass = "astro-ph.EP",
+     year = 2011,
+    month = may,
+   volume = 473,
+    pages = {349-352},
+      doi = {10.1038/nature10092},
+   adsurl = {http://adsabs.harvard.edu/abs/2011Natur.473..349S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012ApJ...757..119B,
+   author = {{Bennett}, D.~P. and {Sumi}, T. and {Bond}, I.~A. and {Kamiya}, K. and 
+	{Abe}, F. and {Botzler}, C.~S. and {Fukui}, A. and {Furusawa}, K. and 
+	{Itow}, Y. and {Korpela}, A.~V. and {Kilmartin}, P.~M. and {Ling}, C.~H. and 
+	{Masuda}, K. and {Matsubara}, Y. and {Miyake}, N. and {Muraki}, Y. and 
+	{Ohnishi}, K. and {Rattenbury}, N.~J. and {Saito}, T. and {Sullivan}, D.~J. and 
+	{Suzuki}, D. and {Sweatman}, W.~L. and {Tristram}, P.~J. and 
+	{Wada}, K. and {Yock}, P.~C.~M. and {MOA Collaboration}},
+    title = "{Planetary and Other Short Binary Microlensing Events from the MOA Short-event Analysis}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1203.4560},
+ primaryClass = "astro-ph.EP",
+ keywords = {gravitational lensing: micro, planets and satellites: detection},
+     year = 2012,
+    month = oct,
+   volume = 757,
+      eid = {119},
+    pages = {119},
+      doi = {10.1088/0004-637X/757/2/119},
+   adsurl = {http://adsabs.harvard.edu/abs/2012ApJ...757..119B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1995ApJ...454L.125A,
+   author = {{Alcock}, C. and {Allsman}, R.~A. and {Alves}, D. and {Axelrod}, T.~S. and 
+	{Bennett}, D.~P. and {Cook}, K.~H. and {Freeman}, K.~C. and 
+	{Griest}, K. and {Guern}, J. and {Lehner}, M.~J. and {Marshall}, S.~L. and 
+	{Peterson}, B.~A. and {Pratt}, M.~R. and {Quinn}, P.~J. and 
+	{Rodgers}, A.~W. and {Stubbs}, C.~W. and {Sutherland}, W.},
+    title = "{First Observation of Parallax in a Gravitational Microlensing Event}",
+  journal = {\apjl},
+   eprint = {astro-ph/9506114},
+ keywords = {COSMOLOGY: DARK MATTER, GALAXY: STELLAR CONTENT, COSMOLOGY: GRAVITATIONAL LENSING, STARS: DISTANCES},
+     year = 1995,
+    month = dec,
+   volume = 454,
+    pages = {L125},
+      doi = {10.1086/309783},
+   adsurl = {http://adsabs.harvard.edu/abs/1995ApJ...454L.125A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{1992ApJ...392..442G,
+   author = {{Gould}, A.},
+    title = "{Extending the MACHO search to about 10 exp 6 solar masses}",
+  journal = {\apj},
+ keywords = {Astronomical Photometry, Gravitational Lenses, Halos, Light Curve, Dark Matter, Hubble Space Telescope, Magellanic Clouds, Stellar Mass},
+     year = 1992,
+    month = jun,
+   volume = 392,
+    pages = {442-451},
+      doi = {10.1086/171443},
+   adsurl = {http://adsabs.harvard.edu/abs/1992ApJ...392..442G},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2007ApJ...664..862D,
+   author = {{Dong}, S. and {Udalski}, A. and {Gould}, A. and {Reach}, W.~T. and 
+	{Christie}, G.~W. and {Boden}, A.~F. and {Bennett}, D.~P. and 
+	{Fazio}, G. and {Griest}, K. and {Szyma{\'n}ski}, M.~K. and 
+	{Kubiak}, M. and {Soszy{\'n}ski}, I. and {Pietrzy{\'n}ski}, G. and 
+	{Szewczyk}, O. and {Wyrzykowski}, {\L}. and {Ulaczyk}, K. and 
+	{Wieckowski}, T. and {Paczy{\'n}ski}, B. and {DePoy}, D.~L. and 
+	{Pogge}, R.~W. and {Preston}, G.~W. and {Thompson}, I.~B. and 
+	{Patten}, B.~M.},
+    title = "{First Space-Based Microlens Parallax Measurement: Spitzer Observations of OGLE-2005-SMC-001}",
+  journal = {\apj},
+   eprint = {astro-ph/0702240},
+ keywords = {Cosmology: Dark Matter, Galaxies: Stellar Content, Cosmology: Gravitational Lensing},
+     year = 2007,
+    month = aug,
+   volume = 664,
+    pages = {862-878},
+      doi = {10.1086/518536},
+   adsurl = {http://adsabs.harvard.edu/abs/2007ApJ...664..862D},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015ApJ...804...20C,
+   author = {{Calchi Novati}, S. and {Gould}, A. and {Udalski}, A. and {Menzies}, J.~W. and 
+	{Bond}, I.~A. and {Shvartzvald}, Y. and {Street}, R.~A. and 
+	{Hundertmark}, M. and {Beichman}, C.~A. and {Yee}, J.~C. and 
+	{Carey}, S. and {Poleski}, R. and {Skowron}, J. and {Koz{\l}owski}, S. and 
+	{Mr{\'o}z}, P. and {Pietrukowicz}, P. and {Pietrzy{\'n}ski}, G. and 
+	{Szyma{\'n}ski}, M.~K. and {Soszy{\'n}ski}, I. and {Ulaczyk}, K. and 
+	{Wyrzykowski}, {\L}. and {OGLE Collaboration} and {Albrow}, M. and 
+	{Beaulieu}, J.~P. and {Caldwell}, J.~A.~R. and {Cassan}, A. and 
+	{Coutures}, C. and {Danielski}, C. and {Dominis Prester}, D. and 
+	{Donatowicz}, J. and {Lon{\v c}ari{\'c}}, K. and {McDougall}, A. and 
+	{Morales}, J.~C. and {Ranc}, C. and {Zhu}, W. and {PLANET Collaboration} and 
+	{Abe}, F. and {Barry}, R.~K. and {Bennett}, D.~P. and {Bhattacharya}, A. and 
+	{Fukunaga}, D. and {Inayama}, K. and {Koshimoto}, N. and {Namba}, S. and 
+	{Sumi}, T. and {Suzuki}, D. and {Tristram}, P.~J. and {Wakiyama}, Y. and 
+	{Yonehara}, A. and {MOA Collaboration} and {Maoz}, D. and {Kaspi}, S. and 
+	{Friedmann}, M. and {Wise Group} and {Bachelet}, E. and {Figuera Jaimes}, R. and 
+	{Bramich}, D.~M. and {Tsapras}, Y. and {Horne}, K. and {Snodgrass}, C. and 
+	{Wambsganss}, J. and {Steele}, I.~A. and {Kains}, N. and {RoboNet Collaboration} and 
+	{Bozza}, V. and {Dominik}, M. and {J{\o}rgensen}, U.~G. and 
+	{Alsubai}, K.~A. and {Ciceri}, S. and {D'Ago}, G. and {Haugb{\o}lle}, T. and 
+	{Hessman}, F.~V. and {Hinse}, T.~C. and {Juncher}, D. and {Korhonen}, H. and 
+	{Mancini}, L. and {Popovas}, A. and {Rabus}, M. and {Rahvar}, S. and 
+	{Scarpetta}, G. and {Schmidt}, R.~W. and {Skottfelt}, J. and 
+	{Southworth}, J. and {Starkey}, D. and {Surdej}, J. and {Wertz}, O. and 
+	{Zarucki}, M. and {MiNDSTEp Consortium} and {Gaudi}, B.~S. and 
+	{Pogge}, R.~W. and {DePoy}, D.~L. and {{$\mu$}FUN Collaboration}
+	},
+    title = "{Pathway to the Galactic Distribution of Planets: Combined Spitzer and Ground-Based Microlens Parallax Measurements of 21 Single-Lens Events}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1411.7378},
+ primaryClass = "astro-ph.EP",
+ keywords = {gravitational lensing: micro, planetary systems, planets and satellites: dynamical evolution and stability},
+     year = 2015,
+    month = may,
+   volume = 804,
+      eid = {20},
+    pages = {20},
+      doi = {10.1088/0004-637X/804/1/20},
+   adsurl = {http://adsabs.harvard.edu/abs/2015ApJ...804...20C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2009ApJ...698L.147G,
+   author = {{Gould}, A. and {Udalski}, A. and {Monard}, B. and {Horne}, K. and 
+	{Dong}, S. and {Miyake}, N. and {Sahu}, K. and {Bennett}, D.~P. and 
+	{Wyrzykowski}, {\L}. and {Soszy{\'n}ski}, I. and {Szyma{\'n}ski}, M.~K. and 
+	{Kubiak}, M. and {Pietrzy{\'n}ski}, G. and {Szewczyk}, O. and 
+	{Ulaczyk}, K. and {OGLE Collaboration} and {Allen}, W. and {Christie}, G.~W. and 
+	{DePoy}, D.~L. and {Gaudi}, B.~S. and {Han}, C. and {Lee}, C.-U. and 
+	{McCormick}, J. and {Natusch}, T. and {Park}, B.-G. and {Pogge}, R.~W. and 
+	{{$\mu$}FUN Collaboration} and {Allan}, A. and {Bode}, M.~F. and 
+	{Bramich}, D.~M. and {Burgdorf}, M.~J. and {Dominik}, M. and 
+	{Fraser}, S.~N. and {Kerins}, E. and {Mottram}, C. and {Snodgrass}, C. and 
+	{Steele}, I.~A. and {Street}, R. and {Tsapras}, Y. and {RoboNet Collaboration} and 
+	{Abe}, F. and {Bond}, I.~A. and {Botzler}, C.~S. and {Fukui}, A. and 
+	{Furusawa}, K. and {Hearnshaw}, J.~B. and {Itow}, Y. and {Kamiya}, K. and 
+	{Kilmartin}, P.~M. and {Korpela}, A. and {Lin}, W. and {Ling}, C.~H. and 
+	{Masuda}, K. and {Matsubara}, Y. and {Muraki}, Y. and {Nagaya}, M. and 
+	{Ohnishi}, K. and {Okumura}, T. and {Perrott}, Y.~C. and {Rattenbury}, N. and 
+	{Saito}, T. and {Sako}, T. and {Skuljan}, L. and {Sullivan}, D.~J. and 
+	{Sumi}, T. and {Sweatman}, W.~L. and {Tristram}, P.~J. and {Yock}, P.~C.~M. and 
+	{MOA Collaboration} and {Albrow}, M. and {Beaulieu}, J.~P. and 
+	{Coutures}, C. and {Calitz}, H. and {Caldwell}, J. and {Fouque}, P. and 
+	{Martin}, R. and {Williams}, A. and {PLANET Collaboration}},
+    title = "{The Extreme Microlensing Event OGLE-2007-BLG-224: Terrestrial Parallax Observation of a Thick-Disk Brown Dwarf}",
+  journal = {\apjl},
+archivePrefix = "arXiv",
+   eprint = {0904.0249},
+ primaryClass = "astro-ph.GA",
+ keywords = {astrometry, gravitational lensing, stars: low-mass, brown dwarfs},
+     year = 2009,
+    month = jun,
+   volume = 698,
+    pages = {L147-L151},
+      doi = {10.1088/0004-637X/698/2/L147},
+   adsurl = {http://adsabs.harvard.edu/abs/2009ApJ...698L.147G},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2003ApJ...591L..53G,
+   author = {{Gould}, A. and {Gaudi}, B.~S. and {Han}, C.},
+    title = "{Resolving the Microlens Mass Degeneracy for Earth-Mass Planets}",
+  journal = {\apjl},
+   eprint = {astro-ph/0304314},
+ keywords = {Cosmology: Gravitational Lensing, Stars: Planetary Systems},
+     year = 2003,
+    month = jul,
+   volume = 591,
+    pages = {L53-L56},
+      doi = {10.1086/377071},
+   adsurl = {http://adsabs.harvard.edu/abs/2003ApJ...591L..53G},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014AJ....147...47B,
+   author = {{Boyajian}, T.~S. and {van Belle}, G. and {von Braun}, K.},
+    title = "{Stellar Diameters and Temperatures. IV. Predicting Stellar Angular Diameters}",
+  journal = {\aj},
+archivePrefix = "arXiv",
+   eprint = {1311.4901},
+ primaryClass = "astro-ph.SR",
+ keywords = {Hertzsprung-Russell and C-M diagrams, planetary systems, stars: early-type, stars: fundamental parameters, stars: general, stars: late-type},
+     year = 2014,
+    month = mar,
+   volume = 147,
+      eid = {47},
+    pages = {47},
+      doi = {10.1088/0004-6256/147/3/47},
+   adsurl = {http://adsabs.harvard.edu/abs/2014AJ....147...47B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+
+


### PR DESCRIPTION
I've expanded the Sec. 11.4 by adding more on low-cadence observations. New FoM is included. A number of smaller changes were made. Bibtex records for all papers cited in 11.4 were added.