### PR TITLE
Update to photoz.tex

### DIFF
--- a/whitepaper/Cosmology/photoz.tex
+++ b/whitepaper/Cosmology/photoz.tex
@@ -14,6 +14,7 @@
 %
 % COMMENTS:
 %    Updated Wed May 18 by MLG.
+%    Minor updates to figures and captions, Sep 14 by MLG.
 %
 % BUGS:
 %
@@ -143,18 +144,18 @@ at $z<0.5$ and $z>2.0$.
 
 \begin{figure}[h]
 \begin{center}
-\includegraphics[width=5.5cm]{figs/photoz/nyears_cat05.png}
-\includegraphics[width=5.5cm]{figs/photoz/nyears_cat20.png}
-\includegraphics[width=5.5cm]{figs/photoz/nyears_cat100.png}
-\includegraphics[width=5.5cm]{figs/photoz/uvisits_cat1.png}
-\includegraphics[width=5.5cm]{figs/photoz/uvisits_cat4.png}
-\includegraphics[width=5.5cm]{figs/photoz/uvisits_cat6.png}
+\includegraphics[width=5cm]{figs/photoz/nyears_cat05.png}
+\includegraphics[width=5cm]{figs/photoz/nyears_cat20.png}
+\includegraphics[width=5cm]{figs/photoz/nyears_cat100.png}
+\includegraphics[width=5cm]{figs/photoz/uvisits_cat1.png}
+\includegraphics[width=5cm]{figs/photoz/uvisits_cat4.png}
+\includegraphics[width=5cm]{figs/photoz/uvisits_cat6.png}
 \caption{Photometric vs. spectroscopic (i.e., catalog truth) redshifts
 for our preliminary simulations. Across the top row we show results from
-0.5, 2.0 and 10.0 years of the LSST survey using catalogs with 2500 test
-and 10000 training galaxies. The photo-$z$'s clearly improve with time
+0.5, 2.0 and 10.0 years of the LSST survey using catalogs with 10000 test
+and 40000 training galaxies. The photo-$z$'s clearly improve with time
 as the survey progresses. Across the bottom row we show results for $1$,
-$56$ (baseline), and $96$ $u$-band visits using catalogs with 10000 test
+$56$ (baseline), and $96$ $u$-band visits, also using catalogs with 10000 test
 and 40000 training galaxies. Between the left-most and middle plot of
 the bottom row, representing 1 and 56 (baseline) $u$-band visits
 respectively, we see that $u$-band data is necessary to limit scatter in
@@ -165,12 +166,12 @@ the photo-$z$'s, especially at $z<0.5$ and $z>2.0$.
 
 \begin{figure}[h]
 \begin{center}
-\includegraphics[width=5.5cm]{figs/photoz/nyears_IQR.png}
-\includegraphics[width=5.5cm]{figs/photoz/nyears_fout.png}
-\includegraphics[width=5.5cm]{figs/photoz/nyears_bias.png}
-\includegraphics[width=5.5cm]{figs/photoz/uvisits_IQR.png}
-\includegraphics[width=5.5cm]{figs/photoz/uvisits_fout.png}
-\includegraphics[width=5.5cm]{figs/photoz/uvisits_bias.png}
+\includegraphics[width=5cm]{figs/photoz/nyears_IQR.png}
+\includegraphics[width=5cm]{figs/photoz/nyears_fout.png}
+\includegraphics[width=5cm]{figs/photoz/nyears_bias.png}
+\includegraphics[width=5cm]{figs/photoz/uvisits_IQR.png}
+\includegraphics[width=5cm]{figs/photoz/uvisits_fout.png}
+\includegraphics[width=5cm]{figs/photoz/uvisits_bias.png}
 \caption{Three photo-$z$ metrics as a function of LSST parameters. From
 left to right, the y-axis is the standard deviation, the fraction of
 outliers, and the bias. The top row shows these statistics as a function


### PR DESCRIPTION
Minor updates to figure plot sizes (so that plots appear in a 3 column 2 row array and match the caption, not 2 column 3 row as they were previously rendering). Minor update to figure captions because the number of points in one set of the plots has changed (and now all runs match in terms of number of catalog galaxies used).