### PR TITLE
Issue/581/opsimdbref

### DIFF
--- a/whitepaper/AGN/AGN_Census.tex
+++ b/whitepaper/AGN/AGN_Census.tex
@@ -172,17 +172,19 @@ and precise astrometric redshifts.
 For predicting the number of detected $z>6$ quasars
 %Compare this magnitude to the
 %one required for identifying $\geq1000$ quasars at $z\geq6$.
-the current
-%enigma\_1189{}
-aquila\_{}1110 OpSim for the main, i.e., WFD survey, gives a
+the
+% current enigma\_1189{}
+% aquila\_{}1110
+\opsimdbname{aquila\_1110}
+\OpSim database for the main, i.e., WFD survey, gives a
 single-visit $5\sigma$-depth
 %old number computed in Bremerton: $Y=22.36$ mag,
 %$Y=21.51$ enigma_\_{}1189
-{\it Y} $= 21.45$ mag as compared to {\it Y} $= 21.51$ for the older enigma\_{}1189 OpSim.
-For the final co-added $5\sigma$-depth the median magnitude from the aquila\_{}1110
-OpSim is
+{\it Y} $= 21.45$ mag (as compared to {\it Y} $= 21.51$ for the older \opsimdbname{enigma\_1189} run).
+For the final co-added $5\sigma$-depth the median magnitude from the \opsimdbname{aquila\_1110}
+\OpSim run is
 %$Y=24.36$. Enigma\_{}1189
-{\it Y}$ = 23.07$ which is more than a magnitude shallower than the older enigma\_{}1189
+{\it Y}$ = 23.07$ which is more than a magnitude shallower than the older \opsimdbname{enigma\_1189}
 depth of {\it Y}$ = 24.36$.
 {\bf The lower {\it Y}-band depth may reduce the total number of quasars at $z > 6$ discovered by LSST by
 a factor of $\sim 2$

--- a/whitepaper/AGN/AGN_Disk_Intrinsic.tex
+++ b/whitepaper/AGN/AGN_Disk_Intrinsic.tex
@@ -249,7 +249,7 @@ the cadence requirements for LSST.
 
 While additional work is required for determining the optimal cadence in order
 to fully capture AGN accretion physics and to enhance AGN selection, it is clear
-that even the nominal DDF sampling (in enigma\_1189) is barely sufficient, and
+that even the nominal DDF sampling (\eg in \opsimdbname{enigma\_1189}) is barely sufficient, and
 more frequent sampling would have been ideal. The ability to detect HFQPOs
 should also improve by increasing the sampling frequency, the amplitudes of such
 features are quite uncertain, as are the (short) duty cycles. Observations,

--- a/whitepaper/Cosmology/supernovacosmology.tex
+++ b/whitepaper/Cosmology/supernovacosmology.tex
@@ -16,7 +16,7 @@
 
 \newcommand{\ml}[1]{\textcolor{red}{[{\bf ML}: #1]}}
 
-Lead authors: 
+Lead authors:
 \credit{jhrlsst},
 \credit{rbiswas4},
 \credit{MichelleLochner}
@@ -447,16 +447,16 @@ in terms the cadence in two example LSST fields.
 % \end{figure*}
 
 
-We analyzed the OpSim output of the Baseline Observing Strategy,
-enigma$\_$1189$\_$sqlite.db{\footnote
-{\url{http://ops2.tuc.noao.edu/runs/}}} which includes Deep Drilling
+We analyzed the OpSim output of an older version of the Baseline Observing Strategy,
+\opsimdbname{enigma\_1189},\footnote
+{\url{http://ops2.tuc.noao.edu/runs/}} which includes Deep Drilling
 Fields (DDF) and the main survey (WFD). While this is no longer the current baseline observing
-strategy, we do not anticipate our conclusions would change with the use of
-\texttt{minion\_1016}. Future work will include repeating our analyses with new OpSim runs, such as
-\texttt{kraken\_1043}, which does not enforce visit pairs, and the new experimental rolling
+strategy, we do not anticipate our conclusions will change with the use of
+\opsimdbref{db:baseCadence} instead. Future work will include repeating our analyses with new OpSim runs, such as
+\opsimdbref{db:NoVisitPairs}, which does not enforce visit pairs, and the new experimental rolling
 cadences.
 
-Using the OpSim output \texttt{enigma\_1189}, we generated
+Using the OpSim output \opsimdbname{enigma\_1189}, we generated
 light curves for a type Ia supernova with a with a redshift of z=0.5 at a few different
 locations. A date in MJD is chosen where the LSST simulated data are
 reasonably well populated. We used the SALT2-extended model
@@ -495,7 +495,7 @@ fields considered, from the DDF and WFD.
 \includegraphics[angle=0,width=14truecm]{figs/SN_290_lc.pdf}
 %\vskip -1.3in
 \caption{An example of a light curve, in six filter bands, of a SN Ia from a DDF in
-\texttt{enigma\_1189}.
+\opsimdbname{enigma\_1189}.
 }
 \label{fig:SNIaLCopsimdeep}
 \end{figure}
@@ -507,7 +507,7 @@ fields considered, from the DDF and WFD.
 %\vskip -1.3in
 \caption{An example of a light curve, where only four filter bands are available, of a SN Ia from
 the WFD survey in
-\texttt{enigma\_1189}.
+\opsimdbname{enigma\_1189}.
 }
 \label{fig:SNIaLCopsimmain}
 \end{figure}
@@ -526,7 +526,7 @@ a distinct filter.}
 
 {\bf Analysis Results:}
 To further study the quality of light curves across the survey, we simulate the same type Ia
-supernova in 16 different fields, including DDF 290 already studied, from the \texttt{enigma\_1189}
+supernova in 16 different fields, including DDF 290 already studied, from the \opsimdbname{enigma\_1189}
 OpSim run and record the average number of visits per 50 day time window
 (\autoref{tab:lcpositions}). A well-known rule of thumb (R. Foley, priv. communication) for good
 quality SN light curves is to
@@ -657,7 +657,7 @@ per SN period per filter & SNDM  & SNQM\\
 % 3959     & (60,+30)  &      44 (0,5,6,15,18,0)   &  1.0 &&\\
 \hline
 \end{tabular}
-\caption{Table of 15 fields in the OpSim run \texttt{enigma\_1189}. The first column is simply an
+\caption{Table of 15 fields in the OpSim run \opsimdbname{enigma\_1189}. The first column is simply an
 index, with the special example fields of the DDF field 290 indicated. The
 position of the fields is shown in column 2. The third column contains the total and per filter
 band number of visits per year and this is averaged per filter per 50 day time window in column 4.
@@ -822,7 +822,8 @@ rectified in future.}
 % --------------------------------------------------------------------
 
 \subsection{Discussion}
-For \texttt{enigma\_1189} (and also, most likely, for the current baseline strategy), the DDF
+
+For \opsimdbname{enigma\_1189} (and also, most likely, for the current baseline strategy), the DDF
 fields will produce an exquisite sample of
 well-characterized SNe for cosmology and astrophysics studies. Further analysis is required to
 determine exactly how many (useful) supernovae will be detected and what the resulting cosmological

--- a/whitepaper/Cosmology/wl.tex
+++ b/whitepaper/Cosmology/wl.tex
@@ -190,7 +190,7 @@ heterogeneous in their variation across the sky, then any multiplicative biases
 that have to be corrected in the data analysis will have severe spatial
 dependence. Homogeneity of depth and seeing certainly helps, and that is an
 observing strategy question as discussed above.  A specific metric for
-multiplicative systematics would be useful in our next OpSim runs.  A useful
+multiplicative systematics would be useful in our next \OpSim runs.  A useful
 metric to be applied to full observing simulations is the mean ratio (and
 spatial variance) of observed vs simulated shear amplitudes over a large sample
 vs z-bins.  Since {\it Multi-Fit} joint star-galaxy fits to individual visits
@@ -200,11 +200,11 @@ cases value uniformity of image quality as well, and this type of metric may be
 applied during observing.
 
 
-\subsection{OpSim Analysis}
+\subsection{\OpSim Analysis}
 
 The distribution of AngularSpread for $2 \times$ rotSkyPos is shown in
-\autoref{fig:WL_AngularSpread_rotSkyPos} for the latest baseline OpSim run,
-minion\_1016.  The left panel shows a sky map for the i-band (in this and the
+\autoref{fig:WL_AngularSpread_rotSkyPos} for the latest baseline \OpSim run,
+\opsimdbref{db:baseCadence}.  The left panel shows a sky map for the i-band (in this and the
 following figures, the sky maps vary only minimally between the two principal
 lensing filters, $r$ and $i$), while the right panel shows a histogram of values
 for each LSST filter.  The distribution of the Kuiper statistic for rotSkyPos
@@ -414,7 +414,7 @@ that, for say, 1000 sq. deg.  A related systematics metric would be the
 suppression of additive PSF systematic residuals in 1000 sq. deg worth of
 pointings over the sky, normalized by that in one field visited 100 times. These
 important simulations will be enabled by the deep-wide full cosmological
-simulation deliverables in DESC Data Challenges 2 and 3, together with OpSim
+simulation deliverables in DESC Data Challenges 2 and 3, together with \OpSim
 runs.
 
 
@@ -441,7 +441,7 @@ up to $\simeq 30$ degrees per visit would require $\simeq 300$ complete
 rotations per night - an upper limit to the additional rotations, but one which might be approached by a requirement for
 rigorous distribution over relatively short timescales.  On the other hand, a very significant improvement
 in distribution could be achieved by simply introducing a constrained randomized rotator
-offset after each filter change, with little or possibly no loss in observing efficiency.  
+offset after each filter change, with little or possibly no loss in observing efficiency.
 Guidance is needed from simulations for the randomization requirement(s), and from science strategy
 for the time scale over which it must be achieved.
 
@@ -458,7 +458,7 @@ opportunity to combine these two randomizations in an efficient observing
 strategy which actually minimizes the number of camera rotations.  Re-visits to
 a field over a range of hour angles and with camera rotations assures full 180
 degree range coverage for CCD coordinates relative to sky.  A metric for this
-can be written and run with OpSim to explore optimization, including minimizing
+can be written and run with \OpSim to explore optimization, including minimizing
 camera rotations.
 
 \subsection{Conclusions}

--- a/whitepaper/MilkyWay/MW_Disk.tex
+++ b/whitepaper/MilkyWay/MW_Disk.tex
@@ -55,7 +55,7 @@ metrics and FoMs (see for example the right panel of Figure
   \citep[e.g.][]{2012ApJ...757..166B, ivezic08}. If there are any filters deemed
   unimportant to variability studies in any fields, it will likely be the
   photometric confusion limit (for static science) that sets the
-  minimum total integration times in those cases.} 
+  minimum total integration times in those cases.}
 
 %Comparison is now needed of multiple
 %strategies that do allocate sufficient observations to inner-Plane
@@ -666,8 +666,8 @@ used to avoid biases in the FoM estimate by the Magellanic Clouds.
 {\it \bf Results:} $FoM_{preSN}$(\opsimdbref{db:baseCadence})=0.13,
 while
 $FoM_{preSN}$(\opsimdbref{db:opstwoPS})=0.83.\footnote{2016-04-25 For
-  comparison, when run on 2015-era OpSim runs {\tt enigma\_1189}
-  (Baseline strategy) and {\tt ops2\_1092} (PanSTARRS-like strategy)
+  comparison, when run on 2015-era \OpSim runs \opsimdbname{enigma\_1189}
+  (Baseline strategy) and \opsimdbname{ops2\_1092} (PanSTARRS-like strategy)
   the results were 0.251 (Baseline) and 0.852 (PanSTARRS-like
   strategy). So the 2016-era OpSim runs show a sharper disadvantage
   suffered by the Baseline cadence, than before the update.} This FoM
@@ -784,7 +784,7 @@ Whether the Plane should be observed as a ``special survey'' or
 \subsection{Conclusions}
 
 
-\new{We answer below the ten questions posed in \autoref{sec:intro:evaluation:caseConclusions}.} 
+\new{We answer below the ten questions posed in \autoref{sec:intro:evaluation:caseConclusions}.}
 
 \new{While the science cases developed thus far all rest on
   variability sensitivity in one way or another, we should point out

--- a/whitepaper/Transients/gw.tex
+++ b/whitepaper/Transients/gw.tex
@@ -111,7 +111,7 @@ acquire color information and distinguish kilonovae from other
 fast-evolving transients.
 
 We use the median inter-night gap  for visits in the same filter derived
-from the candidate Baseline Cadence \texttt{minion\_1016} to show that,
+from the candidate Baseline Cadence \opsimdbref{db:baseCadence} to show that,
 in the absence of a Target of Opportunity (ToO) capability, it is
 \emph{not} possible for LSST  to play a major role in the identification
 of EM counterparts of GW triggers.

--- a/whitepaper/Transients/transientAge.tex
+++ b/whitepaper/Transients/transientAge.tex
@@ -90,8 +90,10 @@ the two.
     in a different band. This criteria could be limited to the
     observations above and below the ecliptic plane, where recovery of
     Solar System objects puts less strain on the cadence requirements.
-    The current 3-visit OpSim (enigma1281) is inadequate since does not
-    include the constraint of one visit being in a different filter.}}
+    The current 3-visit \OpSim run
+    (\opsimdbref{db:NEOswithVisitTriplets}) is inadequate since it does
+    not include the constraint of one visit being in a different
+    filter.}}
 
 {\bf\emph{Furthermore, we note that the currently envisioned
     deep drilling cadence prioritizes depth per visit at the expense

--- a/whitepaper/Variables/multiperiodicpulsators.tex
+++ b/whitepaper/Variables/multiperiodicpulsators.tex
@@ -35,7 +35,7 @@ in their Appendix A.
 Sections 8.6 and 8.7 of the Science Book express the anticipated
 contributions that LSST will make to the study of pulsating variables.
 While the sparseness of observations (low duty cycle) over the LSST
-survey lifetime will make exact period solutions difficult, if not impossible for 
+survey lifetime will make exact period solutions difficult, if not impossible for
 most multiperiodic, short-period pulsating variables, the Science Book
 correctly emphasizes that the photometric precision and multi-color
 information will yield detections of variability that can be treated
@@ -71,7 +71,7 @@ photometrically variable ZZ Cetis.  The square root of the total
 observed pulsational power (intrinsic root-mean-squared signal) in these
 objects is on the order of 1\% and the mean pulsation periods are
 $\sim$10\,min \citep[e.g.,][]{2006ApJ...640..956M}.  Because the pulsation
-periods are $\ll$ the typical LSST revisit time, the survey will essentially 
+periods are $\ll$ the typical LSST revisit time, the survey will essentially
 sample the pulsations randomly in phase.
 
 The ability to detect pulsations relies on the recognition that scatter
@@ -88,8 +88,8 @@ time that are complicated and must be explored in MAF to be understood.
 While consideration of observations across all filters together provides
 the greatest sensitivity to detecting overall variability, the measurement
 of pulsational power in individual filters serves the science needs for
-pulsating stars best.  Since sparse temporal sampling will make measuring 
-the individual periods of complex, multi-modal pulsating stars challenging, 
+pulsating stars best.  Since sparse temporal sampling will make measuring
+the individual periods of complex, multi-modal pulsating stars challenging,
 LSST's greatest contributions to this field may lie
 in its ability to measure relative pulsational power across many
 passbands.  For ZZ Cetis in particular, there is a dependence of
@@ -132,7 +132,7 @@ is displayed in Figure~\ref{fig:vardepth}.
   \centering
   \includegraphics[width=0.76\columnwidth]{figs/vardepth.png}
   \caption{Example output of the {\tt VarDepth} MAF metric run on the
-  current baseline cadence, {\tt minion\_1016}, after 10 years of survey
+  current baseline cadence, \opsimdbref{db:baseCadence}, after 10 years of survey
   operations. Input parameters and SQL queries were set to calculate the
   magnitude limit for detecting 90\% of pulsators with 1\% r.m.s.\
   variability from a cut on the measured variance in the $r$ band
@@ -173,19 +173,20 @@ number of ZZ Cetis known.
 
 % --------------------------------------------------------------------
 
-\subsection{OpSim Analysis}
+\subsection{\OpSim Analysis}
 \label{sec:\secname:analysis}
 
 For comparison purposes, we calculate the number of ZZ Cetis detected in
 both the $u$ and $r$ filters, assuming intrinsic r.m.s.\ variability of
-1\% for two of the currently available OpSim runs: {\tt minion\_1016},
-the current baseline cadence, and {\tt kraken\_1045}, with doubled
-$u$-band exposure times. We require that 90\% of ZZ Cetis with 1\%
-r.m.s.\  variability are detected to the computed ``variability depth,''
-with a tolerance for up to 10\% of nonvariables with the same $u$ and
-$r$ magnitudes to yield false detections.  The total number of ZZ Cetis
-detected for each of these analyses, \emph{if all ZZ Cetis exhibit exactly 
-the assumed level of r.m.s.\ variability}, is provided in Table~\ref{tab:zz1pertab}.
+1\% for two of the currently available \OpSim runs:
+\opsimdbref{db:baseCadence}, the current baseline cadence, and
+\opsimdbref{db:DoubleUbandExptime}, with doubled $u$-band exposure
+times. We require that 90\% of ZZ Cetis with 1\% r.m.s.\  variability
+are detected to the computed ``variability depth,'' with a tolerance for
+up to 10\% of nonvariables with the same $u$ and $r$ magnitudes to yield
+false detections.  The total number of ZZ Cetis detected for each of
+these analyses, \emph{if all ZZ Cetis exhibit exactly the assumed level
+of r.m.s.\ variability}, is provided in \autoref{tab:zz1pertab}.
 
 
 \begin{table}[h]
@@ -193,28 +194,29 @@ the assumed level of r.m.s.\ variability}, is provided in Table~\ref{tab:zz1pert
     \caption{ZZ Ceti Recovery for 1\% R.M.S.\ Variability}\label{tab:zz1pertab}
     \begin{tabular}{| l | l | l |}
     \hline
-    OpSim Run & Filter & \# ZZ Cetis \\ \hline
-     {\tt minion\_1016} & $u$ & 9  \\
+    \OpSim Run & Filter & \# ZZ Cetis \\ \hline
+      \opsimdbref{db:baseCadence} & $u$ & 9  \\
       & $r$ & 127 \\ \hline
-    {\tt kraken\_1045}  & $u$ & 17\\
-    & $r$ & 123  \\ \hline
+      \opsimdbref{db:DoubleUbandExptime} & $u$ & 17\\
+      & $r$ & 123  \\ \hline
     \end{tabular}
 \end{center}
 \end{table}
 
 Clearly LSST appears to fall very short of the proposed figure of merit
-by this measure.   However, the 1\% level of variability assumed for ZZ Cetis in
-this treatment was chosen to assess how well the lowest-amplitude
-ZZ Cetis are recovered by LSST and doesn't fairly represent the more typical, 
-higher amplitude variables.  If we relax this constraint and repeat the
-analysis with ZZ Cetis all modeled as 3\% r.m.s.\ variables (the mean
-r.m.s.\ variation observed), we get the results shown in Table~\ref{tab:zz3pertab}.
-This better represents a total number of ZZ Cetis expected, allowing for
-incompleteness to low amplitude.  While we still do not detect
-$\sim$1000 ZZ Cetis in $u$, overall we see an increase in the total
-number of detected ZZ Cetis by roughly an order of magnitude (in $r$),
-with the {\tt kraken\_1045} simulation reaching markedly closer to the
-$u$-band goal than the {\tt minion\_1016} strategy.
+by this measure.   However, the 1\% level of variability assumed for ZZ
+Cetis in this treatment was chosen to assess how well the
+lowest-amplitude ZZ Cetis are recovered by LSST and doesn't fairly
+represent the more typical, higher amplitude variables.  If we relax
+this constraint and repeat the analysis with ZZ Cetis all modeled as 3\%
+r.m.s.\ variables (the mean r.m.s.\ variation observed), we get the
+results shown in \autoref{tab:zz3pertab}. This better represents a
+total number of ZZ Cetis expected, allowing for incompleteness to low
+amplitude.  While we still do not detect $\sim$1000 ZZ Cetis in $u$,
+overall we see an increase in the total number of detected ZZ Cetis by
+roughly an order of magnitude (in $r$), with the
+\opsimdbref{db:DoubleUbandExptime} simulation reaching markedly closer
+to the $u$-band goal than the \opsimdbref{db:baseCadence} strategy.
 
 
 \begin{table}[h]
@@ -222,10 +224,10 @@ $u$-band goal than the {\tt minion\_1016} strategy.
     \caption{ZZ Ceti Recovery for 3\% R.M.S.\ Variability}\label{tab:zz3pertab}
     \begin{tabular}{| l | l | l |}
     \hline
-    OpSim Run & Filter & \# ZZ Cetis \\ \hline
-     {\tt minion\_1016} & $u$ & 197  \\
+    \OpSim Run & Filter & \# ZZ Cetis \\ \hline
+     \opsimdbref{db:baseCadence} & $u$ & 197  \\
       & $r$ & 1601 \\ \hline
-    {\tt kraken\_1045}  & $u$ & 325\\
+     \opsimdbref{db:DoubleUbandExptime}  & $u$ & 325\\
     & $r$ & 1534  \\ \hline
     \end{tabular}
 \end{center}
@@ -237,28 +239,30 @@ $u$-band goal than the {\tt minion\_1016} strategy.
 \subsection{Discussion}
 \label{sec:\secname:discussion}
 
-This simplistic analysis ignores most subtleties of ZZ Ceti variables, 
-but Table~\ref{tab:zz3pertab} captures the order of magnitude of 
+This simplistic analysis ignores most subtleties of ZZ Ceti variables,
+but Table~\ref{tab:zz3pertab} captures the order of magnitude of
 expected ZZ Ceti detections \emph{from excess scatter alone} for
-the OpSim runs considered.  More sophisticated analysis
+the \OpSim runs considered.  More sophisticated analysis
 of the LSST data will recover additional variables, especially since the
 information about the timing of visits has been completely ignored here.
-The statistical treatment of large populations of stars will also improve the 
-detection of variability over this star-by-star treatment. 
-Still, it appears that the science results for the lowest amplitude ZZ Cetis 
-will be severely limited, and therefore LSST will capture a less-than-complete 
-census of pulsating variable stars. 
+The statistical treatment of large populations of stars will also improve the
+detection of variability over this star-by-star treatment.
+Still, it appears that the science results for the lowest amplitude ZZ Cetis
+will be severely limited, and therefore LSST will capture a less-than-complete
+census of pulsating variable stars.
 
-We emphasize again that low-amplitude ZZ Cetis are the most difficult pulsating 
-stars to observe. LSST will capture variability in higher amplitude ZZ Cetis and 
-other types of variable star more completely, and LSST observations of all 
-candidate pulsating white dwarfs will certainly still be
-worthy on careful analysis.  We note that the {\tt kraken\_1045}
-strategy with 60\,s exposures in $u$ does a much better job of measuring
-stellar variability overall, at the expense of a practically negligible decrease in $r$-band
-detections.  We argue that any observing strategy that increases the number of
-ZZ Cetis detected in the $u$ band will improve LSST's scientific yield for
+We emphasize again that low-amplitude ZZ Cetis are the most difficult
+pulsating stars to observe. LSST will capture variability in higher
+amplitude ZZ Cetis and other types of variable star more completely, and
+LSST observations of all candidate pulsating white dwarfs will certainly
+still be worthy on careful analysis.  We note that the
+\opsimdbref{db:DoubleUbandExptime} strategy with 60\,s exposures in $u$
+does a much better job of measuring stellar variability overall, at the
+expense of a practically negligible decrease in $r$-band detections.  We
+argue that any observing strategy that increases the number of ZZ Cetis
+detected in the $u$ band will improve LSST's scientific yield for
 \emph{all} stellar pulsation studies.
+
 
 % ====================================================================
 
@@ -276,9 +280,9 @@ ZZ Cetis detected in the $u$ band will improve LSST's scientific yield for
  with 18,000 deg$^2$)?}
 
  \item[A1:] Coadded depth is not directly a limitation on detecting variability,
- but both improve with the number of revisits to the same field, $N$, 
+ but both improve with the number of revisits to the same field, $N$,
  as roughly $\sqrt{N}$.  A larger field of view also increases the potential population
- of variable stars discovered, but pushing to higher airmass where data quality is 
+ of variable stars discovered, but pushing to higher airmass where data quality is
  poorer does not make for a good trade unless the survey area is extended to strategically
  target more variable stars, e.g., over more of the Galactic plane.
 
@@ -289,14 +293,14 @@ ZZ Cetis detected in the $u$ band will improve LSST's scientific yield for
  reduced sample rate the rest of the time (while maintaining the nominal
  total visit counts).}
 
- \item[A2:] While the time distribution of observations has not been considered 
- here, this will significantly impact variable star science with LSST. 
+ \item[A2:] While the time distribution of observations has not been considered
+ here, this will significantly impact variable star science with LSST.
  Future development of MAF metrics should address specifically how
- the distribution of visits (rather than only number, area, and signal-to-noise as addressed 
+ the distribution of visits (rather than only number, area, and signal-to-noise as addressed
  above) ease the challenges of amplitude and \emph{period} recovery in sparely sampled
  observations.  Revisit times much shorter than pulsation timescales ($< \sim$5\,min)
  can help to constrain the periods.  Perhaps more importantly, cadences that
- produce the least complicated spectral windows and the highest 
+ produce the least complicated spectral windows and the highest
  ``effective Nyquist frequencies'' will best facilitate period recovery \citep[e.g.,][]{1999A&AS..135....1E}.
 
  \item[Q3:] {\it Does the science case place any constraints on the
@@ -304,18 +308,18 @@ ZZ Cetis detected in the $u$ band will improve LSST's scientific yield for
  (especially in the $u$-band where longer exposures would minimize the
  impact of the readout noise)?}
 
- \item[A3:] We specifically support increased time spent in the 
+ \item[A3:] We specifically support increased time spent in the
  $u$-band, with the goal of measuring the relative pulsation amplitudes
- in multiple filters. Increased signal-to-noise per $u$-band exposure enables 
+ in multiple filters. Increased signal-to-noise per $u$-band exposure enables
  more measurements of pulsational power in $u$, though pulsating star
- science would be hurt by a corresponding decrease in the total number of 
+ science would be hurt by a corresponding decrease in the total number of
  $u$-band visits per field .
 
  \item[Q4:] {\it Does the science case place any constraints on the
  Galactic plane coverage (spatial coverage, temporal sampling, visits per
  band)?}
 
- \item[A4:] The Galactic plane contains a higher concentration of multi-periodic 
+ \item[A4:] The Galactic plane contains a higher concentration of multi-periodic
  pulsating stars that LSST will be able to characterize in the time domain.
  Pulsating star science benefits from more survey time spent in the Galactic
  plane.
@@ -335,13 +339,13 @@ ZZ Cetis detected in the $u$ band will improve LSST's scientific yield for
  cadence for deep drilling fields?}
 
  \item[A6:] The results of the {\tt VarDepth} MAF metric run on the
- current baseline cadence, {\tt minion\_1016}, shows that after 10 years, 
- deep drilling fields are sensitive to pulsation \emph{amplitude} measurements
- in the $r$-band $\approx$1.5\,mag fainter than for identical objects in 
- the main survey.  The improvement to period recoverability 
- could be far greater in deep drilling fields, but new MAF metrics must
- be developed to demonstrate this and to help select between specific
- proposed cadences.
+ current baseline cadence, \opsimdbref{db:baseCadence}, shows that after
+ 10 years, deep drilling fields are sensitive to pulsation
+ \emph{amplitude} measurements in the $r$-band $\approx$1.5\,mag fainter
+ than for identical objects in the main survey.  The improvement to
+ period recoverability could be far greater in deep drilling fields, but
+ new MAF metrics must be developed to demonstrate this and to help
+ select between specific proposed cadences.
 
  The possibility to obtain data at a high cadence for extended periods of time in the deep drilling fields will also facilitate the asteroseismology of solar-like oscillators ($\sim$minutes for main-sequence stars and $\sim$hours for red giants). However, an MAF metric is required to determine the specific requirements.
 
@@ -359,22 +363,22 @@ ZZ Cetis detected in the $u$ band will improve LSST's scientific yield for
  the bands or in a  selected set); a greatly enhanced cadence for a small
  area?}
 
- \item[A8:] A few hours of continuous sampling of a few fields during 
- commissioning would produce immediate science results for many 
- multi-modal pulsating stars, as well as help accelerate LSST's ultimate 
+ \item[A8:] A few hours of continuous sampling of a few fields during
+ commissioning would produce immediate science results for many
+ multi-modal pulsating stars, as well as help accelerate LSST's ultimate
  characterization of variable stars in these fields.
 
  Furthermore, by mimicking the 10-yr survey for a small area, the scientific community can obtain evidence-based estimates of the yeild of different variable classes and example power spectra. This will also provide proof-of-concept data that will facilitate the recruitment of scientists to work on LSST.
- 
+
 
  \item[Q9:] {\it Does the science case place any constraints on the
  sampling of observing conditions (e.g., seeing, dark sky, airmass),
  possibly as a function of band, etc.?}
 
- \item[A9:] The {\tt VarDepth} MAF metric can help assess how the 
- adjustments made by the observing strategy to observing conditions 
+ \item[A9:] The {\tt VarDepth} MAF metric can help assess how the
+ adjustments made by the observing strategy to observing conditions
  affect the variable star science output.
- 
+
 
  \item[Q10:] {\it Does the case have science drivers that would require
  real-time exposure time optimization to obtain nearly constant

--- a/whitepaper/specialsurveys.tex
+++ b/whitepaper/specialsurveys.tex
@@ -83,5 +83,3 @@ such investigations.
 \input{SpecialSurveys/M67_special.tex}
 
 % --------------------------------------------------------------------
-
-\navigationbar


### PR DESCRIPTION
All references to OpSim databases should now use `\opsimdbref` (or at least `\opsimdbname` for old simulations not in the Chapter 2 table). 